### PR TITLE
Use Redis zsets directly for determining match tracked status

### DIFF
--- a/config.js
+++ b/config.js
@@ -52,7 +52,7 @@ var defaults = {
     "GROUP": "", //for specifying the group of apps that should be run when entry point is invoked
     "MMSTATS_DATA_INTERVAL": 3, //minutes between requests for MMStats data
     "DEFAULT_DELAY": 1000, // delay between API requests (default: 1000)
-    "SCANNER_DELAY": 500, //delay for scanner API requests (more time-sensitive)
+    "SCANNER_DELAY": 2000, //delay for scanner API requests (stricter rate limit)
     "SCANNER_PARALLELISM": 1, //Number of simultaneous API requests to make in scanner
     "MMR_PARALLELISM": 10,
     "PARSER_PARALLELISM": 1,
@@ -63,7 +63,6 @@ var defaults = {
     "ENABLE_RECAPTCHA": "", //set to enable the recaptcha on the Request page
     "ENABLE_ADS": "", //set to turn on ads
     "ENABLE_MATCH_CACHE": "", // set to enable caching matches (Redis)
-    "ENABLE_INSERT_ALL_MATCHES": "1", //set to enable inserting all matches
     "ENABLE_RANDOM_MMR_UPDATE": "", //set to update MMRs after ranked matches
     "ENABLE_POSTGRES_MATCH_STORE_WRITE": "1", //set to enable writing match data to postgres (default on)
     "ENABLE_CASSANDRA_MATCH_STORE_READ": "1", //set to enable reading match data from cassandra

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -285,7 +285,7 @@ function processExpand(entries, meta)
         {
             e.type = "runes";
             e.slot = e.player1;
-            e.key = e.value.toString();
+            e.key = String(e.value);
             e.value = 1;
             expand(e);
         },
@@ -300,7 +300,7 @@ function processExpand(entries, meta)
             //subsequent players assisted
             //still not perfect as dota can award kills to players when they're killed by towers/creeps and chat event does not reflect this
             //e.slot = e.player2;
-            //e.key = e.player1.toString();
+            //e.key = String(e.player1);
             //currently disabled in favor of combat log kills
         },
         "CHAT_MESSAGE_GLYPH_USED": function (e)
@@ -336,7 +336,7 @@ function processExpand(entries, meta)
             //Barracks can always be deduced 
             //They go in incremental powers of 2, starting by the Dire side to the Dire Side, Bottom to Top, Melee to Ranged
             //so Bottom Melee Dire Rax = 1 and Top Ranged Radiant Rax = 2048.
-            e.key = e.value.toString();
+            e.key = String(e.value);
             expand(e);
         },
         "CHAT_MESSAGE_FIRSTBLOOD": function (e)

--- a/routes/api.js
+++ b/routes/api.js
@@ -783,8 +783,6 @@ module.exports = function (db, redis, cassandra)
             else if (req.file)
             {
                 console.log(req.file);
-                //var key = req.file.originalname + Date.now();
-                //var key = Math.random().toString(16).slice(2);
                 const hash = crypto.createHash('md5');
                 hash.update(req.file.buffer);
                 var key = hash.digest('hex');

--- a/store/buildSets.js
+++ b/store/buildSets.js
@@ -20,6 +20,7 @@ module.exports = function buildSets(db, redis, cb)
                 }
                 docs.forEach(function (player)
                 {
+                    // Refresh donators with expire date in the future
                     redis.zadd('tracked', moment().add(1, 'month').format('X'), player.account_id);
                 });
                 cb(err);
@@ -32,6 +33,7 @@ module.exports = function buildSets(db, redis, cb)
             console.log('error occurred during buildSets: %s', err);
             return cb(err);
         }
+        // Remove inactive players from tracked set
         redis.zremrangebyscore('tracked', 0, moment().subtract(config.UNTRACK_DAYS, 'days').format('X'));
         return cb(err);
     });

--- a/svc/backupscanner.js
+++ b/svc/backupscanner.js
@@ -20,13 +20,13 @@ function start(err)
   {
     throw err;
   }
-  queries.getSets(redis, function (err, result)
+  redis.zrange('tracked', 0, -1, function (err, ids)
   {
     if (err)
     {
       throw err;
     }
-    async.eachLimit(Object.keys(result.trackedPlayers), parallelism, processPlayer, start);
+    async.eachLimit(ids, parallelism, processPlayer, start);
   });
 }
 
@@ -113,7 +113,6 @@ function processMatch(match_id, cb)
             origin: "scanner",
             skipCounts: false,
             skipAbilityUpgrades: false,
-            skipParse: false,
             cassandra: cassandra,
           }, function (err)
           {

--- a/svc/parser.js
+++ b/svc/parser.js
@@ -194,7 +194,7 @@ function runParse(match, job, cb)
     {
         if (response.statusCode !== 200)
         {
-            exit(response.statusCode.toString());
+            exit(String(response.statusCode));
         }
     }).on('error', exit);
     var bz;

--- a/svc/requests.js
+++ b/svc/requests.js
@@ -35,7 +35,7 @@ function processRequest(job, cb)
                 attempts: 1,
                 lifo: true,
                 cassandra: cassandra,
-                skipParse: false,
+                forceParse: true,
             }, waitParse);
         });
     }

--- a/svc/scanner.js
+++ b/svc/scanner.js
@@ -13,14 +13,13 @@ const getData = utility.getData;
 const generateJob = utility.generateJob;
 const async = require('async');
 const parallelism = config.SCANNER_PARALLELISM;
-const api_hosts = config.STEAM_API_HOST.split(',');
+//const api_hosts = config.STEAM_API_HOST.split(',');
 //note that the limit for this endpoint seems to be around 5 calls/IP/minute
 //endpoint usually takes around 2 seconds to return data
 //therefore each IP should generally avoid requesting more than once every 10 seconds
 const delay = Number(config.SCANNER_DELAY);
 const PAGE_SIZE = 100;
-var trackedPlayers;
-buildSets(db, redis, function(err)
+buildSets(db, redis, function (err)
 {
     if (err)
     {
@@ -33,7 +32,7 @@ function start()
 {
     if (config.START_SEQ_NUM)
     {
-        redis.get("match_seq_num", function(err, result)
+        redis.get("match_seq_num", function (err, result)
         {
             if (err || !result)
             {
@@ -50,7 +49,7 @@ function start()
         //never do this in production to avoid skipping sequence number if we didn't pull .env properly
         var container = generateJob("api_history",
         {});
-        getData(container.url, function(err, data)
+        getData(container.url, function (err, data)
         {
             if (err)
             {
@@ -67,145 +66,119 @@ function start()
 
     function scanApi(seq_num)
     {
-        queries.getSets(redis, function(err, result)
+        //set local vars
+        var arr = [];
+        var matchBuffer = {};
+        var completePages = {};
+        for (var i = 0; i < parallelism; i++)
         {
-            if (err)
-            {
-                throw err;
-            }
-            //set local vars
-            trackedPlayers = result.trackedPlayers;
-            if (config.NODE_ENV === 'development')
-            {
-                console.log(JSON.stringify(trackedPlayers));
-            }
-            var arr = [];
-            var matchBuffer = {};
-            var completePages = {};
-            for (var i = 0; i < parallelism; i++)
-            {
-                arr.push(seq_num + i * PAGE_SIZE);
-            }
-            var next_seq_num = seq_num;
-            //async parallel calls
-            async.each(arr, processPage, finishPageSet);
+            arr.push(seq_num + i * PAGE_SIZE);
+        }
+        var next_seq_num = seq_num;
+        //async parallel calls
+        async.each(arr, processPage, finishPageSet);
 
-            function processPage(match_seq_num, cb)
+        function processPage(match_seq_num, cb)
+        {
+            var container = generateJob("api_sequence",
             {
-                var container = generateJob("api_sequence",
-                {
-                    start_at_match_seq_num: match_seq_num
-                });
-                getData(
-                {
-                    url: container.url,
-                    delay: delay,
-                }, function(err, data)
-                {
-                    if (err)
-                    {
-                        return cb(err);
-                    }
-                    var resp = data.result && data.result.matches ? data.result.matches : [];
-                    if (resp.length >= PAGE_SIZE)
-                    {
-                        completePages[arr.indexOf(match_seq_num)] = Math.max(next_seq_num, resp[PAGE_SIZE - 1].match_seq_num + 1);
-                    }
-                    console.log("[API] match_seq_num:%s, matches:%s", match_seq_num, resp.length);
-                    async.each(resp, processMatch, cb);
-                });
-            }
-
-            function processMatch(match, cb)
+                start_at_match_seq_num: match_seq_num
+            });
+            getData(
             {
-                var insert = false;
-                var skipParse = true;
-                if (match.players.some(function(p)
-                    {
-                        return (p.account_id in trackedPlayers);
-                    }))
-                {
-                    insert = true;
-                    skipParse = false;
-                }
-                else if (config.ENABLE_INSERT_ALL_MATCHES)
-                {
-                    insert = true;
-                }
-                //check if match was previously processed
-                redis.get('scanner_insert:' + match.match_id, function(err, result)
-                {
-                    if (err)
-                    {
-                        return finishMatch(err);
-                    }
-                    //don't insert this match if we already processed it recently
-                    //deduplicate matches in this page set
-                    if (insert && !result && !matchBuffer[match.match_id])
-                    {
-                        matchBuffer[match.match_id] = 1;
-                        insertMatch(db, redis, match,
-                        {
-                            type: "api",
-                            origin: "scanner",
-                            cassandra: cassandra,
-                            skipParse: skipParse,
-                        }, function(err)
-                        {
-                            if (!err)
-                            {
-                                //mark with long-lived key to indicate complete (persist between restarts)
-                                redis.setex('scanner_insert:' + match.match_id, 3600 * 8, 1);
-                            }
-                            finishMatch(err);
-                        });
-                    }
-                    else
-                    {
-                        finishMatch(err);
-                    }
-                });
-
-                function finishMatch(err)
-                {
-                    if (err)
-                    {
-                        console.error("failed to insert match from scanApi %s", match.match_id);
-                        console.error(err);
-                    }
-                    return cb(err);
-                }
-            }
-
-            function finishPageSet(err)
+                url: container.url,
+                delay: delay,
+            }, function (err, data)
             {
                 if (err)
                 {
-                    //something bad happened, retry this page
-                    console.error(err);
-                    return scanApi(seq_num);
+                    return cb(err);
+                }
+                var resp = data.result && data.result.matches ? data.result.matches : [];
+                if (resp.length >= PAGE_SIZE)
+                {
+                    completePages[arr.indexOf(match_seq_num)] = Math.max(next_seq_num, resp[PAGE_SIZE - 1].match_seq_num + 1);
+                }
+                console.log("[API] match_seq_num:%s, matches:%s", match_seq_num, resp.length);
+                async.each(resp, processMatch, cb);
+            });
+        }
+
+        function processMatch(match, cb)
+        {
+            //check if match was previously processed
+            redis.get('scanner_insert:' + match.match_id, function (err, result)
+            {
+                if (err)
+                {
+                    return finishMatch(err);
+                }
+                //don't insert this match if we already processed it recently
+                //deduplicate matches in this page set
+                if (!result && !matchBuffer[match.match_id])
+                {
+                    matchBuffer[match.match_id] = 1;
+                    insertMatch(db, redis, match,
+                    {
+                        type: "api",
+                        origin: "scanner",
+                        cassandra: cassandra,
+                    }, function (err)
+                    {
+                        if (!err)
+                        {
+                            //mark with long-lived key to indicate complete (persist between restarts)
+                            redis.setex('scanner_insert:' + match.match_id, 3600 * 8, 1);
+                        }
+                        finishMatch(err);
+                    });
                 }
                 else
                 {
-                    //find next seq num by last contiguous seq num (completed page)
-                    var next_seq_num = seq_num;
-                    for (var i = 0; i < parallelism; i++)
-                    {
-                        if (!completePages[i])
-                        {
-                            break;
-                        }
-                        next_seq_num = completePages[i];
-                    }
-                    console.log("next_seq_num: %s", next_seq_num);
-                    redis.set("match_seq_num", next_seq_num);
-                    //completed inserting matches on this page
-                    //if page set isn't full, delay the next iteration
-                    return setTimeout(function() {
-                        return scanApi(next_seq_num);
-                    }, Object.keys(matchBuffer).length < (parallelism * PAGE_SIZE) ? 3000 : 0);
+                    finishMatch(err);
                 }
+            });
+
+            function finishMatch(err)
+            {
+                if (err)
+                {
+                    console.error("failed to insert match from scanApi %s", match.match_id);
+                    console.error(err);
+                }
+                return cb(err);
             }
-        });
+        }
+
+        function finishPageSet(err)
+        {
+            if (err)
+            {
+                //something bad happened, retry this page
+                console.error(err);
+                return scanApi(seq_num);
+            }
+            else
+            {
+                //find next seq num by last contiguous seq num (completed page)
+                var next_seq_num = seq_num;
+                for (var i = 0; i < parallelism; i++)
+                {
+                    if (!completePages[i])
+                    {
+                        break;
+                    }
+                    next_seq_num = completePages[i];
+                }
+                console.log("next_seq_num: %s", next_seq_num);
+                redis.set("match_seq_num", next_seq_num);
+                //completed inserting matches on this page
+                //if page set isn't full, delay the next iteration
+                return setTimeout(function ()
+                {
+                    return scanApi(next_seq_num);
+                }, Object.keys(matchBuffer).length < (parallelism * PAGE_SIZE) ? 3000 : 0);
+            }
+        }
     }
 }

--- a/tasks/getMatch.js
+++ b/tasks/getMatch.js
@@ -31,7 +31,7 @@ getData(
         {
             skipCounts: true,
             skipAbilityUpgrades: true,
-            skipParse: false,
+            forceParse: true,
             cassandra: cassandra,
             attempts: 1,
         }, function(err)

--- a/util/compute.js
+++ b/util/compute.js
@@ -489,7 +489,6 @@ function renderMatch(m)
     if (m.players[0] && m.players[0].gold_reasons)
     {
         m.incomeData = generateIncomeData(m);
-        //m.treeMapData = generateTreemapData(m);
     }
     //create graph data
     if (m.players[0] && m.players[0].gold_t)
@@ -659,36 +658,6 @@ function generateIncomeData(match)
     };
 }
 
-function generateTreemapData(match)
-{
-    var data = [];
-    match.players.forEach(function (player)
-    {
-        var hero = constants.heroes[player.hero_id] ||
-        {};
-        data.push(
-        {
-            name: hero.localized_name,
-            id: player.hero_id.toString(),
-            value: ~~(player.gold_per_min * match.duration / 60)
-        });
-    });
-    for (var key in constants.gold_reasons)
-    {
-        var reason = constants.gold_reasons[key].name;
-        match.players.forEach(function (player)
-        {
-            var g = player.gold_reasons;
-            data.push(
-            {
-                name: reason,
-                parent: player.hero_id.toString(),
-                value: g[key] || 0
-            });
-        });
-    }
-    return data;
-}
 /**
  * Count the words that occur in a set of messages
  * - messages: the messages to create the counts over


### PR DESCRIPTION
Scales better as the number of tracked players increases.

Previous behavior is to load the ids from Redis into a JavaScript object, then check for membership in the object.  New behavior is to do the membership checks on the IDs directly against the zset.

Reviewers:
@albertcui 
@nicholashh 