### PR TITLE
Add clarification about API key and username

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Quickstart (Docker)
 ----
 * Install Docker: `curl -sSL https://get.docker.com/ | sh`. If you are on Windows, make sure you shared the working drive with Docker.
 * Create .env file with required config values in KEY=VALUE format (see config.js for a full listing of options) `cp .env_example .env`
-  * `STEAM_API_KEY` You need this in order to access the Steam Web API, which is used to fetch basic match data, player profile data, and cosmetic item data.
-  * `STEAM_USER, STEAM_PASS` A Steam account is required to fetch replay salts. It is recommended to use a new account for this purpose (you won't be able to use the account on two different hosts at the same time). This is not required if you don't need to download/parse replays.
+  * `STEAM_API_KEY` You need this in order to access the Steam Web API, which is used to fetch basic match data, player profile data, and cosmetic item data. You can use your main account to obtain the API key; it does not have to match the account used for the `STEAM_USER` and `STEAM_PASS` options.
+  * `STEAM_USER, STEAM_PASS` A Steam account is required to fetch replay salts. It is recommended to use a new account for this purpose (you won't be able to use the account on two different hosts at the same time, and the account must not have SteamGuard). This is not required if you don't need to download/parse replays.
 * Start containers and initialize databases: `docker-compose up`
 * Make some changes and commit them.
 * Submit a pull request.  Wait for it to be reviewed and merged.


### PR DESCRIPTION
This updates README.md to help people avoid two problems that I ran into while setting up Docker:

1. The API key and username/password do not have to be connected to the same account.

2. The logon will fail if the account has SteamGuard enabled.