### PR TITLE
don't autoparse insignificant matches

### DIFF
--- a/store/queries.js
+++ b/store/queries.js
@@ -1030,7 +1030,7 @@ function insertMatch(match, options, cb) {
   }
 
   function decideReplayParse(cb) {
-    if (options.skipParse || !utility.isSignificant(match)) {
+    if (options.skipParse || (!utility.isSignificant(match) && !options.forceParse)) {
       // not parsing this match
       return cb();
     }

--- a/store/queries.js
+++ b/store/queries.js
@@ -1014,7 +1014,7 @@ function insertMatch(match, options, cb) {
 
   function decideGcData(cb) {
     // TODO use reliable queue
-    if (options.origin === 'scanner' && (match.match_id % 100) < Number(config.GCDATA_PERCENT)) {
+    if (options.origin === 'scanner' && utility.isSignificant(match) && (match.match_id % 100) < Number(config.GCDATA_PERCENT)) {
       redis.lpush('gcQueue', JSON.stringify({
         match_id: match.match_id,
       }));
@@ -1030,7 +1030,7 @@ function insertMatch(match, options, cb) {
   }
 
   function decideReplayParse(cb) {
-    if (options.skipParse) {
+    if (options.skipParse || !utility.isSignificant(match)) {
       // not parsing this match
       return cb();
     }


### PR DESCRIPTION
avoid heavy load due to dark moon matches.

Also affects modes like AD, ARDM, but most people don't care about those modes anyway.  Parsing still works on request.