### PR TITLE
add minimum match rating for rankings

### DIFF
--- a/store/queries.js
+++ b/store/queries.js
@@ -490,8 +490,9 @@ function updateRankings(match, cb) {
     if (err) {
       return cb(err);
     }
-    const matchScore = (avg && !isNaN(Number(avg))) ?
-      Math.pow(Math.max(avg / 1000, 1), 7) :
+    const ratingMin = 2000;
+    const matchScore = (avg && !isNaN(Number(avg)) && avg >= ratingMin) ?
+      Math.pow(avg / ratingMin, 7) :
       undefined;
     return async.each(match.players, (player, cb) => {
       if (!player.account_id || player.account_id === utility.getAnonymousAccountId()) {


### PR DESCRIPTION
* This change adds a minimum average match rating for matches to be considered for rankings (currently 2000).
* This reduces redis memory usage