### PR TITLE
return successful replay salt fetches

### DIFF
--- a/routes/spec.js
+++ b/routes/spec.js
@@ -3647,15 +3647,22 @@ Please keep request rate to approximately 1/s.
            .asCallback((err, result) => {
           */
           async.map([].concat(req.query.match_id || []).slice(0, 20),
-            (matchId, cb) => getGcData(db, redis, {
-              match_id: matchId,
-              noRetry: true,
-            }, cb),
+            (matchId, cb) =>
+              getGcData(db, redis, {
+                match_id: matchId,
+                noRetry: true,
+              }, (err, result) => {
+                if (err) {
+                  console.error(err);
+                }
+                return cb(null, result);
+              }
+            ),
             (err, result) => {
               if (err) {
                 return cb(err);
               }
-              return res.json(result);
+              return res.json(result.filter(Boolean));
             });
         },
       },


### PR DESCRIPTION
Previously this returned a 500 error if any salt failed to fetch.

This was inflating the number of artificial 500 errors and also reducing effective throughput.