### PR TITLE
Add a couple more instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Tech Stack
 Quickstart (Docker)
 ----
 * Install Docker: `curl -sSL https://get.docker.com/ | sh`. If you are on Windows, make sure you shared the working drive with Docker.
+* Install Docker Compose: `curl -L "https://github.com/docker/compose/releases/download/1.11.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose`. If you are on Windows, docker-compose comes with the msi package.
+* If you are on Windows, make sure that you have the line endings configured properly in git: `git config --global core.autocrlf input`. This will make sure that after commmit/checkout the line endings will stay UNIX style in this repository.
 * Create .env file with required config values in KEY=VALUE format (see config.js for a full listing of options) `cp .env_example .env`
   * `STEAM_API_KEY` You need this in order to access the Steam Web API, which is used to fetch basic match data, player profile data, and cosmetic item data. You can use your main account to obtain the API key; it does not have to match the account used for the `STEAM_USER` and `STEAM_PASS` options.
   * `STEAM_USER, STEAM_PASS` A Steam account is required to fetch replay salts. It is recommended to use a new account for this purpose (you won't be able to use the account on two different hosts at the same time, and the account must not have SteamGuard). This is not required if you don't need to download/parse replays.


### PR DESCRIPTION
Hi guys, 
after trying to spin-up odota/core on linux and windows, I've decided to add instructions to README.md how to:

- install docker-compose on linux
- configure git in such way, that the UNIX style line endings are preserved on windows after checkout/commit. Otherwise docker/prepend.sh is not working and sometime later the linting (I think) is unhappy.

Regards 🍻 
Georgi