### PR TITLE
moved item purchases form COMBATLOG to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Quickstart (Docker)
 ----
 * Install Docker: `curl -sSL https://get.docker.com/ | sh`. If you are on Windows, make sure you shared the working drive with Docker.
 * Install Docker Compose: `curl -L "https://github.com/docker/compose/releases/download/1.11.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose`. If you are on Windows, docker-compose comes with the msi package.
-* If you are on Windows, make sure that you have the line endings configured properly in git: `git config --global core.autocrlf input`. This will make sure that after commmit/checkout the line endings will stay UNIX style in this repository.
+* If you are on Windows, make sure that you have the line endings configured properly in git: `git config --global core.autocrlf input`. This will make sure that after commit/checkout the line endings will stay UNIX style in this repository.
 * Create .env file with required config values in KEY=VALUE format (see config.js for a full listing of options) `cp .env_example .env`
   * `STEAM_API_KEY` You need this in order to access the Steam Web API, which is used to fetch basic match data, player profile data, and cosmetic item data. You can use your main account to obtain the API key; it does not have to match the account used for the `STEAM_USER` and `STEAM_PASS` options. You can request an API key here: https://steamcommunity.com/dev/apikey
   * `STEAM_USER, STEAM_PASS` A Steam account is required to fetch replay salts. It is recommended to use a new account for this purpose (you won't be able to use the account on two different hosts at the same time, and the account must not have Steam Guard enabled). This is not required if you don't need to download/parse replays.
@@ -53,9 +53,9 @@ Resources
 ----
 * Join us on Discord (https://discord.gg/0o5SQGbXuWCNDcaF)! We're always happy to help and answer questions.
 * The following blog posts may help you understand the codebase/architecture:
+  * General Learnings: https://odota.github.io/blog/2016/05/13/learnings/
   * Architecture: https://odota.github.io/blog/2016/05/15/architecture/
   * Deployment/Infrastructure: https://odota.github.io/blog/2016/08/10/deployment/
-  * General Learnings: https://odota.github.io/blog/2016/05/13/learnings/
 
 History
 ----

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -2,7 +2,7 @@
  * Strips off "item_" from strings, and nullifies dota_unknown.
  * Does not mutate the original string.
  **/
-const item_ids = require('dotaconstants').item_ids;
+const itemIds = require('dotaconstants').item_ids;
 
 function translate(input) {
   if (input === 'dota_unknown') {
@@ -192,7 +192,7 @@ function processExpand(entries, meta) {
         type: 'xp_reasons',
       });
     },
-    DOTA_COMBATLOG_PURCHASE(e) {
+    DOTA_COMBATLOG_PURCHASE() {
       // Moved to actions due to purchases before start of the game (during picks)
 
       // purchase
@@ -214,7 +214,7 @@ function processExpand(entries, meta) {
           unit,
           key,
           type: 'purchase_log',
-        }); 
+        });
       } */
     },
     DOTA_COMBATLOG_BUYBACK(e) {
@@ -294,7 +294,7 @@ function processExpand(entries, meta) {
     actions(e) {
       // purchase
       if (e.key === "16") {
-        const key = translate(item_ids[e.value.toString()]);  // "item_stout_shield" by id
+        const key = translate(itemIds[e.value.toString()]);  // "item_stout_shield" by id
         expand({
           time: e.time,
           value: 1,
@@ -558,7 +558,7 @@ function processExpand(entries, meta) {
     if (types[e.type]) {
       types[e.type](e);
     } else {
-      //console.log('parser emitted unhandled type: %s', e.type);
+      // console.log('parser emitted unhandled type: %s', e.type);
     }
   }
   return output;

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -37,7 +37,6 @@ function processExpand(entries, meta) {
     }));
   }
 
-  let gameStarted = false;
   const types = {
     DOTA_COMBATLOG_DAMAGE(e) {
       // damage
@@ -181,10 +180,6 @@ function processExpand(entries, meta) {
     },
     DOTA_COMBATLOG_GAME_STATE(e) {
       // state
-      // check if game started
-      if (e.value === 4) {
-        gameStarted = true;
-      }
     },
     DOTA_COMBATLOG_XP(e) {
       // xp gain
@@ -298,7 +293,7 @@ function processExpand(entries, meta) {
       // we should only do this for events where we don't have a PURCHASE entry since
       // this will not work immediately for new items (we have to manually update dotaconstants).
       // We check if this is a pregame
-      if (e.key === '16' && !gameStarted) {
+      if (e.key === '16' && e.time < meta.game_zero) {
         const key = translate(itemIds[e.value.toString()]);  // "item_stout_shield" by id
         // i.e. dotaconstants doesn't have this item
         if (typeof key === 'undefined') {

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -293,7 +293,7 @@ function processExpand(entries, meta) {
     },
     actions(e) {
       // purchase
-      if (e.key === "16") {
+      if (e.key === '16') {
         const key = translate(itemIds[e.value.toString()]);  // "item_stout_shield" by id
         expand({
           time: e.time,

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -37,7 +37,7 @@ function processExpand(entries, meta) {
     }));
   }
 
-  var gameStarted = false
+  let gameStarted = false;
   const types = {
     DOTA_COMBATLOG_DAMAGE(e) {
       // damage
@@ -184,7 +184,7 @@ function processExpand(entries, meta) {
       // check if game started
       // not sure if this value means start of the game
       if (e.value === 4) {
-        gameStarted = true
+        gameStarted = true;
       }
     },
     DOTA_COMBATLOG_XP(e) {
@@ -296,15 +296,15 @@ function processExpand(entries, meta) {
     actions(e) {
       // purchase
 
-      // we should only do this for events where we don't have a PURCHASE entry
-      // since this will not work immediately for new items (we have to manually update dotaconstants).
+      // we should only do this for events where we don't have a PURCHASE entry since
+      // this will not work immediately for new items (we have to manually update dotaconstants).
       // We check if this is a pregame
       if (e.key === '16' && !gameStarted) {
         const key = translate(itemIds[e.value.toString()]);  // "item_stout_shield" by id
         // i.e. dotaconstants doesn't have this item
-        if (typeof(key) == "undefined") {
+        if (typeof key === 'undefined') {
           expand(Object.assign({}, e, { value: 1 }));
-          return
+          return;
         }
         expand({
           time: e.time,

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -182,7 +182,6 @@ function processExpand(entries, meta) {
     DOTA_COMBATLOG_GAME_STATE(e) {
       // state
       // check if game started
-      // not sure if this value means start of the game
       if (e.value === 4) {
         gameStarted = true;
       }

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -178,7 +178,7 @@ function processExpand(entries, meta) {
         type: 'gold_reasons',
       });
     },
-    DOTA_COMBATLOG_GAME_STATE(e) {
+    DOTA_COMBATLOG_GAME_STATE() {
       // state
     },
     DOTA_COMBATLOG_XP(e) {


### PR DESCRIPTION
fixes #1445 

In opendota starting items aren't shown if they were bought before the start of the game (this may happen in all pick when player picked his hero, for example). Right now, opendota gets purchases from combat_log, but combat log events appear only after beginning of the match. However, events with type of "actions" exists during picks too, so i suggest moving purchase tracking from combat log to actions. This pull request changes processExpand, so that it generate purchase events from actions events, not from combat_log.

However:
- I tested it on json generating, but not on whole project
- It doesn't get hero name by slot as i don't know how to do this, but it isn't needed, is it? (you get slot by hero name anyway) 
`  const slot = ('slot' in e) ? e.slot : meta.hero_to_slot[e.unit];`
- Right now odota/parser doesn't get which item was purchased in onSpectatorPlayerUnitOrders, so i made pull request fixing it https://github.com/odota/parser/pull/11