### PR TITLE
Ignore aegis deaths

### DIFF
--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -163,7 +163,7 @@ function processExpand(entries, meta) {
 
       if (key === aegisHolder) {
         // The aegis holder was killed
-        if (aegisDeathTime == null) {
+        if (aegisDeathTime === null) {
           // It is the first time they have been killed this tick
           // If the hero is meepo than the clones will also get killed
           aegisDeathTime = e.time;

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -41,22 +41,6 @@ function processExpand(entries, meta) {
   // Used to ignore meepo clones killing themselves
   let aegisDeathTime = null;
 
-  function getAegisHolder(heroSlot) {
-    // There are two names for each hero stored in meta.hero_to_slot,
-    // so we need to get the one with the most underscores
-    const aegisHolderPossibilities = [];
-    Object.keys(meta.hero_to_slot).forEach((hero) => {
-      const slot = meta.hero_to_slot[hero];
-      if (slot === heroSlot) {
-        aegisHolderPossibilities.push(hero);
-      }
-    });
-    const ndx = aegisHolderPossibilities
-      .map(hero => hero.match(/_/g || []).length) // Get number of _'s
-      .reduce((iMax, x, i, arr) => (x > arr[iMax] ? i : iMax), 0); // Get index of most _'s
-    return aegisHolderPossibilities[ndx];
-  }
-
   const types = {
     DOTA_COMBATLOG_DAMAGE(e) {
       // damage
@@ -161,7 +145,7 @@ function processExpand(entries, meta) {
         });
       }
 
-      if (key === aegisHolder) {
+      if (meta.hero_to_slot[key] === aegisHolder) {
         // The aegis holder was killed
         if (aegisDeathTime === null) {
           // It is the first time they have been killed this tick
@@ -414,7 +398,7 @@ function processExpand(entries, meta) {
       });
     },
     CHAT_MESSAGE_AEGIS(e) {
-      aegisHolder = getAegisHolder(e.player1);
+      aegisHolder = e.player1;
 
       expand({
         time: e.time,
@@ -423,7 +407,7 @@ function processExpand(entries, meta) {
       });
     },
     CHAT_MESSAGE_AEGIS_STOLEN(e) {
-      aegisHolder = getAegisHolder(e.player1);
+      aegisHolder = e.player1;
 
       expand({
         time: e.time,

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -35,6 +35,28 @@ function processExpand(entries, meta) {
     }));
   }
 
+  // Tracks current aegis holder so we can ignore kills that pop aegis
+  let aegisHolder = null;
+
+  // Used to ignore meepo clones killing themselves
+  let aegisDeathTime = null;
+
+  function getAegisHolder(heroSlot) {
+    // There are two names for each hero stored in meta.hero_to_slot,
+    // so we need to get the one with the most underscores
+    const aegisHolderPossibilities = [];
+    Object.keys(meta.hero_to_slot).forEach((hero) => {
+      const slot = meta.hero_to_slot[hero];
+      if (slot === heroSlot) {
+        aegisHolderPossibilities.push(hero);
+      }
+    });
+    const ndx = aegisHolderPossibilities
+      .map(hero => hero.match(/_/g || []).length) // Get number of _'s
+      .reduce((iMax, x, i, arr) => (x > arr[iMax] ? i : iMax), 0); // Get index of most _'s
+    return aegisHolderPossibilities[ndx];
+  }
+
   const types = {
     DOTA_COMBATLOG_DAMAGE(e) {
       // damage
@@ -104,11 +126,16 @@ function processExpand(entries, meta) {
         type: 'healing',
       }));
     },
-    DOTA_COMBATLOG_MODIFIER_ADD() {
+    DOTA_COMBATLOG_MODIFIER_ADD(e) {
       // gain buff/debuff
       // e.attackername // unit that buffed (use source to get the hero? chen/enchantress)
       // e.inflictor // the buff
       // e.targetname // target of buff (possibly illusion)
+
+      // Aegis expired
+      if (e.inflictor === 'modifier_aegis_regen') {
+        aegisHolder = null;
+      }
     },
     DOTA_COMBATLOG_MODIFIER_REMOVE() {
       // modifier_lost
@@ -134,16 +161,29 @@ function processExpand(entries, meta) {
         });
       }
 
-      // If it is not a suicide
-      if (e.attackername !== key) {
-        expand(Object.assign({}, e, {
-          unit,
-          key,
-          type: 'killed',
-        }));
+      if (key === aegisHolder) {
+        // The aegis holder was killed
+        if (aegisDeathTime == null) {
+          // It is the first time they have been killed this tick
+          // If the hero is meepo than the clones will also get killed
+          aegisDeathTime = e.time;
+          return;
+        } else if (aegisDeathTime !== e.time) {
+          // We are after the aegis death tick, so clear everything
+          aegisDeathTime = null;
+          aegisHolder = null;
+        } else {
+          // We are on the same tick, so it is a clone dying
+          return;
+        }
       }
 
-      // If a hero was killed
+      // Ignore suicides
+      if (e.attackername === key) {
+        return;
+      }
+
+      // If a hero was killed log extra information
       if (e.targethero && !e.targetillusion) {
         expand({
           time: e.time,
@@ -161,6 +201,12 @@ function processExpand(entries, meta) {
           type: 'killed_by',
         });
       }
+
+      expand(Object.assign({}, e, {
+        unit,
+        key,
+        type: 'killed',
+      }));
     },
     DOTA_COMBATLOG_ABILITY(e) {
       // Value field is 1 or 2 for toggles
@@ -368,6 +414,8 @@ function processExpand(entries, meta) {
       });
     },
     CHAT_MESSAGE_AEGIS(e) {
+      aegisHolder = getAegisHolder(e.player1);
+
       expand({
         time: e.time,
         type: e.type,
@@ -375,6 +423,8 @@ function processExpand(entries, meta) {
       });
     },
     CHAT_MESSAGE_AEGIS_STOLEN(e) {
+      aegisHolder = getAegisHolder(e.player1);
+
       expand({
         time: e.time,
         type: e.type,


### PR DESCRIPTION
Fixes some of issue #726.  Tried to include comments with what everything does, let me know if anything is confusing.  I ran some diff tests on some games to check if it works, which I included below.  I think it might be easier to just run it on dev and compare games with prod though.

```javascript
When run on a game with no roshan kills there was no diff

Here is an example of a diff from a game where a ta died once with an aegis:
// Gyro kills
  -"hero_kills": 6,
  +"hero_kills": 5,
    -"npc_dota_hero_templar_assassin": 2,
    +"npc_dota_hero_templar_assassin": 1,
      -"key": "npc_dota_hero_templar_assassin",          "time": 1250        },        {

// TA Killed by
    -"npc_dota_hero_gyrocopter": 2,
    +"npc_dota_hero_gyrocopter": 1,
// Teamfights
  -"deaths": 9,
  +"deaths": 8,
        -"npc_dota_hero_templar_assassin": 1
      -"deaths": 2,
      +"deaths": 1,
        -"88": {              "130": 1            },

Here is an example of a diff from a game a meepo died with aegis died twice:

//meepo killed by
-"npc_dota_hero_meepo": 16,        "npc_dota_hero_ogre_magi": 3,        "npc_dota_hero_rubick": 1,
+"npc_dota_hero_ogre_magi": 2,

// rubick
  "hero_kills": 10,
  "hero_kills": 9,
    "npc_dota_hero_meepo": 1,
      "key": "npc_dota_hero_meepo",          "time": 1318        },        {

// ogre magi
  "hero_kills": 8,
  "hero_kills": 7,
    "npc_dota_hero_meepo": 3,
    "npc_dota_hero_meepo": 2,
      "key": "npc_dota_hero_meepo",          "time": 1965        },        {

// teamfights:
  -"deaths": 6,
  +"deaths": 5,
  -    "deaths": 1,          "deaths_pos": {            "124": {              "128": 1            }          },
  +    "deaths": 0,          "deaths_pos": {},
  -    "killed": {            "npc_dota_hero_meepo": 1          },
  +    "killed": {},
  -"deaths": 6,      "end": 1980,      "last_death": 1965,
  +"deaths": 5,      "end": 1969,      "last_death": 1954,
  -    "deaths": 1,          "deaths_pos": {            "156": {              "140": 1            }          }, 
  +    "deaths": 0,          "deaths_pos": {},
  -    "killed": {            "npc_dota_hero_meepo": 1          },
  +    "killed": {},

```
I have never submitted a PR that has had this many commits made between when I started and finished, so let me know if I need to do some rebase stuff to keep the history clean.