### PR TITLE
Remove Chatweel Filtering

### DIFF
--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -444,9 +444,7 @@ function processExpand(entries, meta) {
       expand(e);
     },
     chatwheel(e) {
-      if (Number(e.key) >= 86) {
-        expand(e);
-      }
+      expand(e);
     },
     interval(e) {
       if (e.time >= 0) {


### PR DESCRIPTION
This is now filtered in the UI instead, meaning people who use the api will be able to see the other chatwheel events.