### PR TITLE
implement live games data ingestion/endpoint

### DIFF
--- a/routes/spec.js
+++ b/routes/spec.js
@@ -3766,6 +3766,37 @@ Please keep request rate to approximately 3/s.
         },
       },
     },
+    '/live': {
+      get: {
+        summary: 'GET /live',
+        description: 'Get top currently ongoing live games',
+        tags: ['live'],
+        parameters: [],
+        responses: {
+          200: {
+            description: 'Success',
+            schema: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                },
+              },
+            },
+          },
+        },
+        route: () => '/live',
+        func: (req, res, cb) => {
+          redis.zrangebyscore('liveGames', '-inf', 'inf', (err, rows) => {
+            if (err) {
+              return cb(err);
+            }
+            const entries = rows.map(r => JSON.parse(r));
+            return res.json(entries);
+          });
+        },
+      },
+    },
     '/schema': {
       get: {
         summary: 'GET /schema',

--- a/util/utility.js
+++ b/util/utility.js
@@ -145,6 +145,18 @@ function generateJob(type, payload) {
         type: 'api',
       };
     },
+    api_top_live_game() {
+      return {
+        url: `${apiUrl}/IDOTA2Match_570/GetTopLiveGame/v1/?key=${apiKey}&partner=0`,
+        type: 'api',
+      };
+    },
+    api_realtime_stats() {
+      return {
+        url: `${apiUrl}/IDOTA2MatchStats_570/GetRealtimeStats/v1?key=${apiKey}&server_steam_id=${payload.server_steam_id}`,
+        type: 'api',
+      };
+    },
     parse() {
       return {
         title: [type, payload.match_id].join(),
@@ -204,7 +216,13 @@ function getData(url, cb) {
         || !res
         || res.statusCode !== 200
         || !body
-        || (steamApi && !body.result && !body.response && !body.player_infos && !body.teams)
+        || (steamApi
+          && !body.result
+          && !body.response
+          && !body.player_infos
+          && !body.teams
+          && !body.game_list
+          && !body.match)
         || (stratzApi && (!body.results || !body.results[0]))
       ) {
         // invalid response


### PR DESCRIPTION
Implement new endpoint:
/live: Returns 100 matches with highest server_steam_id values from Valve GetTopLiveGame endpoint

Not implemented yet:
Getting detailed data including match_id from GetRealTimeStats endpoint