### PR TITLE
fix incorrect api limit exceeded error

### DIFF
--- a/svc/web.js
+++ b/svc/web.js
@@ -159,7 +159,7 @@ app.use((req, res, cb) => {
         error: 'rate limit exceeded',
       });
     }
-    if (config.ENABLE_API_LIMIT && !whitelistedPaths.includes(req.path) && !res.locals.isAPIRequest && Number(resp[2]) >= config.API_FREE_LIMIT) {
+    if (config.ENABLE_API_LIMIT && !res.locals.isAPIRequest && !whitelistedPaths.includes(req.path) && Number(resp[2]) >= config.API_FREE_LIMIT) {
       return res.status(429).json({
         error: 'monthly api limit exeeded',
       });


### PR DESCRIPTION
On some paths i am getting `monthly api limit reached` even though i am using a key and below 50,000 requests. Changing these two conditionals should make the check for an API key succeed before checking if a path is whitelisted or not. 