### PR TITLE
Revert "Bump eslint from 5.7.0 to 5.9.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -228,16 +228,19 @@
       }
     },
     "acorn": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
-      "integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg==",
-      "dev": true
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.0.3"
+      }
     },
     "adm-zip": {
       "version": "0.4.11",
@@ -278,7 +281,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -369,14 +372,11 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
-    "ascli": {
+    "arrify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
-      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-      "requires": {
-        "colour": "~0.7.1",
-        "optjs": "~3.2.2"
-      }
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -675,11 +675,6 @@
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
       "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
     },
-    "bufferview": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bufferview/-/bufferview-1.0.1.tgz",
-      "integrity": "sha1-ev10pF+Tf6QiodM4wIu/3HbNcl0="
-    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -736,11 +731,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
-    },
-    "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
     "caseless": {
       "version": "0.12.0",
@@ -905,45 +895,10 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -971,11 +926,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-    },
-    "colour": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -1203,11 +1153,6 @@
         "ms": "2.0.0"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -1304,25 +1249,18 @@
       }
     },
     "del": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^6.1.0",
+        "globby": "^5.0.0",
         "is-path-cwd": "^1.0.0",
         "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
         "rimraf": "^2.2.8"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
       }
     },
     "delayed-stream": {
@@ -1541,9 +1479,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.9.0.tgz",
-      "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.7.0.tgz",
+      "integrity": "sha512-zYCeFQahsxffGl87U2aJ7DPyH8CbWgxBC213Y8+TCanhUTf2gEvfq3EKpHmEcozTLyPmGe9LZdMAwC/CpJBM5A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1587,9 +1525,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-          "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -1766,14 +1704,13 @@
       "dev": true
     },
     "espree": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
+      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.2",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "^5.6.0",
+        "acorn-jsx": "^4.1.1"
       }
     },
     "esprima": {
@@ -2242,13 +2179,13 @@
       "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c="
     },
     "flat-cache": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.2.tgz",
-      "integrity": "sha512-KByBY8c98sLUAGpnmjEdWTrtrLZRtZdwds+kAL/ciFXTCb7AZgqKsAnVnYFQj1hxepwO8JKN/8AsRWwLq+RK0A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^3.0.0",
+        "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
         "write": "^0.2.1"
       }
@@ -2914,12 +2851,13 @@
       "dev": true
     },
     "globby": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
         "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
         "glob": "^7.0.3",
         "object-assign": "^4.0.1",
         "pify": "^2.0.0",
@@ -3158,11 +3096,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ipaddr.js": {
       "version": "1.6.0",
@@ -3569,14 +3502,6 @@
       "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
       "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA="
     },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3868,12 +3793,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
-    "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-      "optional": true
-    },
     "nanomatch": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
@@ -4001,11 +3920,6 @@
           "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
         }
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -4163,27 +4077,14 @@
         "wordwrap": "~1.0.0"
       }
     },
-    "optjs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
-    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "^1.0.0"
-      }
-    },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -4204,12 +4105,6 @@
       "requires": {
         "p-limit": "^1.1.0"
       }
-    },
-    "p-map": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-      "dev": true
     },
     "p-try": {
       "version": "1.0.0",
@@ -4957,7 +4852,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -5441,54 +5336,273 @@
         "buffer-crc32": "^0.2",
         "bytebuffer": "^5.0",
         "steam-crypto": "^0.0",
-        "steam-resources": "git+https://github.com/seishun/node-steam-resources.git#1403939a12ba467a4b82c8ccbc279bbcdad43588"
+        "steam-resources": "git+https://github.com/seishun/node-steam-resources.git#v1.0.0"
       },
       "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+        "steam-resources": {
+          "version": "1.0.0",
+          "bundled": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "long": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
-          "integrity": "sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8="
-        },
-        "protobufjs": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-4.1.3.tgz",
-          "integrity": "sha1-jjbRsCJsu2jWR+S0TCoUTzfyd54=",
-          "requires": {
-            "ascli": "~1",
-            "bytebuffer": "~4 >=4.1",
-            "glob": "^5.0.10",
-            "yargs": "^3.10.0"
+            "bytebuffer": "5.0.0",
+            "protobufjs": "4.1.2"
           },
           "dependencies": {
             "bytebuffer": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-4.1.0.tgz",
-              "integrity": "sha1-TFgmngUqseSx9/82T9+zzogpBqo=",
+              "version": "5.0.0",
+              "bundled": true,
               "requires": {
-                "bufferview": "~1",
-                "long": "~2 >=2.3.0"
+                "long": "3.0.1"
+              },
+              "dependencies": {
+                "long": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "protobufjs": {
+              "version": "4.1.2",
+              "bundled": true,
+              "requires": {
+                "ascli": "1.0.0",
+                "bytebuffer": "4.1.0",
+                "glob": "5.0.15",
+                "yargs": "3.29.0"
+              },
+              "dependencies": {
+                "ascli": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "colour": "0.7.1",
+                    "optjs": "3.2.1-boom"
+                  },
+                  "dependencies": {
+                    "colour": {
+                      "version": "0.7.1",
+                      "bundled": true
+                    },
+                    "optjs": {
+                      "version": "3.2.1-boom",
+                      "bundled": true
+                    }
+                  }
+                },
+                "bytebuffer": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "bufferview": "1.0.1",
+                    "long": "2.4.0"
+                  },
+                  "dependencies": {
+                    "bufferview": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    },
+                    "long": {
+                      "version": "2.4.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "bundled": true,
+                  "requires": {
+                    "inflight": "1.0.4",
+                    "inherits": "2.0.1",
+                    "minimatch": "3.0.0",
+                    "once": "1.3.2",
+                    "path-is-absolute": "1.0.0"
+                  },
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.3.2",
+                        "wrappy": "1.0.1"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "bundled": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "brace-expansion": "1.1.1"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.1",
+                          "bundled": true,
+                          "requires": {
+                            "balanced-match": "0.2.1",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.1",
+                              "bundled": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "bundled": true,
+                      "requires": {
+                        "wrappy": "1.0.1"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "yargs": {
+                  "version": "3.29.0",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "3.0.3",
+                    "decamelize": "1.1.1",
+                    "os-locale": "1.4.0",
+                    "window-size": "0.1.2",
+                    "y18n": "3.2.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "bundled": true
+                    },
+                    "cliui": {
+                      "version": "3.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.1",
+                        "strip-ansi": "3.0.0",
+                        "wrap-ansi": "1.0.0"
+                      },
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "code-point-at": "1.0.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.0"
+                          },
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "number-is-nan": "1.0.0"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "number-is-nan": "1.0.0"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "wrap-ansi": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "string-width": "1.0.1"
+                          }
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.1.1",
+                      "bundled": true
+                    },
+                    "os-locale": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "lcid": "1.0.0"
+                      },
+                      "dependencies": {
+                        "lcid": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "invert-kv": "1.0.0"
+                          },
+                          "dependencies": {
+                            "invert-kv": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "window-size": {
+                      "version": "0.1.2",
+                      "bundled": true
+                    },
+                    "y18n": {
+                      "version": "3.2.0",
+                      "bundled": true
+                    }
+                  }
+                }
               }
             }
-          }
-        },
-        "steam-resources": {
-          "version": "git+https://github.com/seishun/node-steam-resources.git#1403939a12ba467a4b82c8ccbc279bbcdad43588",
-          "from": "git+https://github.com/seishun/node-steam-resources.git#1403939a12ba467a4b82c8ccbc279bbcdad43588",
-          "requires": {
-            "bytebuffer": "^5.0",
-            "protobufjs": "^4.1"
           }
         }
       }
@@ -5640,9 +5754,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-          "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -6034,11 +6148,6 @@
         "isexe": "^2.0.0"
       }
     },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-    },
     "winston": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.3.tgz",
@@ -6064,35 +6173,6 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
-      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -6121,11 +6201,6 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
     "yamljs": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
@@ -6133,40 +6208,6 @@
       "requires": {
         "argparse": "^1.0.7",
         "glob": "^7.0.5"
-      }
-    },
-    "yargs": {
-      "version": "3.32.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-      "requires": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ws": "^5.1.1"
   },
   "devDependencies": {
-    "eslint": "^5.9.0",
+    "eslint": "^5.7.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "mocha": "^5.2.0"


### PR DESCRIPTION
Reverts odota/core#1787

For some reason dependabot update are casuing node-steam to break due to updating package-lock