### PR TITLE
Added OR condition on heroStats query to include heroes with 0 result…

### DIFF
--- a/svc/herostats.js
+++ b/svc/herostats.js
@@ -19,7 +19,7 @@ function doHeroStats(cb) {
               case when hero_id is not null then count(*) else null end as pick,
               heroes.id as hero_id
               FROM heroes
-			        LEFT JOIN public_player_matches on public_player_matches.hero_id = heroes.id
+              LEFT JOIN public_player_matches on public_player_matches.hero_id = heroes.id
               LEFT JOIN 
               (SELECT * FROM public_matches
               TABLESAMPLE SYSTEM_ROWS(10000000)

--- a/svc/herostats.js
+++ b/svc/herostats.js
@@ -22,8 +22,9 @@ function doHeroStats(cb) {
               JOIN 
               (SELECT * FROM public_matches
               TABLESAMPLE SYSTEM_ROWS(10000000)
-              WHERE start_time > ?
-              AND start_time < ?
+              WHERE ((start_time > ?
+              AND start_time < ?)
+              OR start_time IS NULL)
               AND avg_rank_tier IS NOT NULL)
               matches_list USING(match_id)
               WHERE hero_id > 0
@@ -41,8 +42,9 @@ function doHeroStats(cb) {
               FROM heroes
               LEFT JOIN player_matches ON heroes.id = player_matches.hero_id
               LEFT JOIN matches on player_matches.match_id = matches.match_id
-              WHERE start_time > ?
-              AND start_time < ?
+              WHERE (start_time > ?
+              AND start_time < ?)
+              OR start_time IS NULL
               GROUP BY heroes.id
               ORDER BY heroes.id
           `, [minTime, maxTime])
@@ -56,8 +58,9 @@ function doHeroStats(cb) {
               FROM heroes
               LEFT JOIN picks_bans ON heroes.id = picks_bans.hero_id AND is_pick IS FALSE
               LEFT JOIN matches on picks_bans.match_id = matches.match_id
-              WHERE start_time > ?
-              AND start_time < ?
+              WHERE (start_time > ?
+              AND start_time < ?)
+              OR start_time IS NULL
               GROUP BY heroes.id
               ORDER BY heroes.id
           `, [minTime, maxTime])

--- a/svc/herostats.js
+++ b/svc/herostats.js
@@ -15,8 +15,8 @@ function doHeroStats(cb) {
       db.raw(`
               SELECT
               floor(avg_rank_tier / 10) as rank_tier,
-              sum(case when radiant_win = (player_slot < 128) then 1 when hero_id is null then null else 0 end) as win, 
-              case when hero_id is not null then count(*) else null end as pick,
+              sum(case when radiant_win = (player_slot < 128) then 1 when public_player_matches.hero_id is null then null else 0 end) as win, 
+              case when public_player_matches.hero_id is not null then count(*) else null end as pick,
               heroes.id as hero_id
               FROM heroes
               LEFT JOIN public_player_matches on public_player_matches.hero_id = heroes.id
@@ -28,7 +28,7 @@ function doHeroStats(cb) {
               AND avg_rank_tier IS NOT NULL)
               matches_list USING(match_id)
               WHERE heroes.id > 0
-              GROUP BY rank_tier, hero_id, heroes.id
+              GROUP BY rank_tier, public_player_matches.hero_id, heroes.id
               ORDER BY heroes.id
           `, [minTime, maxTime])
         .asCallback(cb);

--- a/svc/herostats.js
+++ b/svc/herostats.js
@@ -18,8 +18,8 @@ function doHeroStats(cb) {
               sum(case when radiant_win = (player_slot < 128) then 1 when hero_id is null then null else 0 end) as win, 
               case when hero_id is not null then count(*) else null end as pick,
               heroes.id as hero_id
-              FROM public_player_matches 
-              RIGHT JOIN heroes on heroes.id = public_player_matches.hero_id
+              FROM heroes
+			        LEFT JOIN public_player_matches on public_player_matches.hero_id = heroes.id
               LEFT JOIN 
               (SELECT * FROM public_matches
               TABLESAMPLE SYSTEM_ROWS(10000000)


### PR DESCRIPTION
Issue: https://github.com/odota/web/issues/1887

Modified the heroStats query to included heroes that have 0 games played (e.g. new heroes). It will then include the hero_id, pro_win, pro_pick and pro_ban attributes in GET /heroStats for those heroes.