### PR TITLE
create new parsed_matches table

### DIFF
--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -498,6 +498,10 @@ CREATE TABLE IF NOT EXISTS hero_search (
 CREATE INDEX IF NOT EXISTS hero_search_teamA_idx_gin ON hero_search USING GIN(teamA);
 CREATE INDEX IF NOT EXISTS hero_search_teamB_idx_gin ON hero_search USING GIN(teamB);
 
+CREATE TABLE IF NOT EXISTS parsed_matches (
+  PRIMARY KEY (match_id),
+  match_id bigint
+);
 
 DO $$
 BEGIN

--- a/store/queries.js
+++ b/store/queries.js
@@ -868,6 +868,17 @@ function insertMatch(match, options, cb) {
           });
       }
 
+      function upsertParsedMatch(cb) {
+        if (match.start_time) {
+          return upsert(trx, 'parsed_matches', {
+            match_id: match.match_id,
+          }, {
+            match_id: match.match_id,
+          }, cb);
+        }
+        return cb();
+      }
+
       function exit(err) {
         if (err) {
           console.error(err);
@@ -886,6 +897,7 @@ function insertMatch(match, options, cb) {
         upsertTeamMatch,
         upsertTeamRankings,
         upsertMatchLogs,
+        upsertParsedMatch,
       }, exit);
     });
   }

--- a/store/queries.js
+++ b/store/queries.js
@@ -869,7 +869,7 @@ function insertMatch(match, options, cb) {
       }
 
       function upsertParsedMatch(cb) {
-        if (match.start_time) {
+        if (match.version) {
           return upsert(trx, 'parsed_matches', {
             match_id: match.match_id,
           }, {


### PR DESCRIPTION
Creating a new parsed_matches in order to store all parsed matches
This is for https://github.com/odota/core/issues/1907

First PR, a new table
Next PR will be for the API call