### PR TITLE
Fixed items with charges not being added correctly to purchase log

### DIFF
--- a/CONTRIBUTORS.js
+++ b/CONTRIBUTORS.js
@@ -22,4 +22,5 @@ module.exports = {
   81164255: {}, // jgalat
   48990698: {}, // fcostantini
   385676285: {}, // 102
+  89457522: {}, // 27bslash
 };

--- a/processors/populate.js
+++ b/processors/populate.js
@@ -62,6 +62,13 @@ function populate(e, container) {
             time: e.time,
             key: e.key,
           };
+          if (e.type === 'purchase_log' && e.charges) {
+            let maxCharges = 1;
+            if (e.key === 'tango') maxCharges = 3;
+            for (let i = 1; i < maxCharges / e.charges; i += 1) {
+              t.push(arrEntry);
+            }
+          }
           if (e.type === 'kills_log' && e.tracked_death) {
             arrEntry = Object.assign({}, {
               tracked_death: e.tracked_death,

--- a/processors/populate.js
+++ b/processors/populate.js
@@ -62,12 +62,13 @@ function populate(e, container) {
             time: e.time,
             key: e.key,
           };
-          if (e.type === 'purchase_log' && e.charges) {
-            let maxCharges = 1;
-            if (e.key === 'tango') maxCharges = 3;
-            for (let i = 1; i < maxCharges / e.charges; i += 1) {
-              t.push(arrEntry);
-            }
+          const maxCharges = e.key === 'tango' ? 3 : 1;
+          if (e.type === 'purchase_log' && e.charges > maxCharges) {
+            arrEntry = {
+              time: e.time,
+              key: e.key,
+              charges: e.charges,
+            };
           }
           if (e.type === 'kills_log' && e.tracked_death) {
             arrEntry = Object.assign({}, {

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -263,6 +263,7 @@ function processExpand(entries, meta) {
         value: 1,
         unit,
         key,
+        charges: e.charges,
         type: 'purchase',
       });
       // don't include recipes in purchase logs
@@ -272,6 +273,7 @@ function processExpand(entries, meta) {
           value: 1,
           unit,
           key,
+          charges: e.charges,
           type: 'purchase_log',
         });
       }

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -622,7 +622,11 @@ You can find data that can be used to convert hero and ability IDs and other inf
                             },
                             key: {
                               description: 'Integer item ID',
-                              type: 'string',
+                              type: 'integer',
+                            },
+                            charges: {
+                              description: 'Integer amount of charges',
+                              type: 'integer',
                             },
                           },
                         },


### PR DESCRIPTION
Currently Items that can be stacked do not show up correctly in the items tab:
![image](https://user-images.githubusercontent.com/24210259/97215568-848c2680-17bc-11eb-8ab0-dcfda6ba07fd.png)
![image](https://user-images.githubusercontent.com/24210259/97215754-c61cd180-17bc-11eb-97a8-4d88f993fe13.png)

Changed to add copies of the item depending on the max charges and the current charges an item has.
![image](https://user-images.githubusercontent.com/24210259/97215601-9241ac00-17bc-11eb-8f19-2e65a2c52b88.png)
![image](https://user-images.githubusercontent.com/24210259/97215728-bef5c380-17bc-11eb-9750-173b0c282b8f.png)
