### PR TITLE
Changed data type for purchase_log key

### DIFF
--- a/routes/spec.js
+++ b/routes/spec.js
@@ -621,8 +621,8 @@ You can find data that can be used to convert hero and ability IDs and other inf
                               type: 'integer',
                             },
                             key: {
-                              description: 'Integer item ID',
-                              type: 'integer',
+                              description: 'String item ID',
+                              type: 'string',
                             },
                             charges: {
                               description: 'Integer amount of charges',


### PR DESCRIPTION
Key was previously integer, but the server responses are strings. Causes deserialization error

fixes #2300