### PR TITLE
Return webhook info on creation

### DIFF
--- a/routes/webhookManagement.js
+++ b/routes/webhookManagement.js
@@ -97,7 +97,7 @@ hooks.route('/')
         if (rows.length === 0) {
           throw Error('Could not create webhook');
         }
-        return res.sendStatus(200);
+        return res.json(rows[0]);
       })
       .catch((err) => {
         if (err.message === 'URL exists') {


### PR DESCRIPTION
Hello 👋 thank y'all for your wonderful service!

I was building something using webhooks but ran into an issue where after creating a new webhook, I was not returned any info about the created resource and was unable to reference it in the future.

This PR makes it so when you `POST` to create a new webhook, the newly created webhook is returned back to you, allowing you to know it's ID so to reference it later.

I didn't see any tests to update but please let me know if I missed anything!