### PR TITLE
Fix documentation for '/players/{account_id}/rankings'

### DIFF
--- a/CONTRIBUTORS.js
+++ b/CONTRIBUTORS.js
@@ -25,4 +25,5 @@ module.exports = {
   89457522: {}, // 27bslash
   115074332: {}, // Sheemap
   94620402: {}, // lmmfranco
+  193480093: {}, // angary
 };

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -2168,7 +2168,11 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     description: 'The ID value of the hero played',
                     type: 'string',
                   },
-                  rank: {
+                  score: {
+                    description: 'hero_score',
+                    type: 'number',
+                  },
+                  percent_rank: {
                     description: 'percent_rank',
                     type: 'number',
                   },


### PR DESCRIPTION
Fix to the issue here: https://github.com/odota/core/issues/2409