### PR TITLE
return hook id from insert call

### DIFF
--- a/routes/webhookManagement.js
+++ b/routes/webhookManagement.js
@@ -92,7 +92,7 @@ hooks.route('/')
             players,
             leagues,
           },
-        });
+        }, ['hook_id']);
       }).then((rows) => {
         if (rows.length === 0) {
           throw Error('Could not create webhook');


### PR DESCRIPTION
SO it turns out my previous PR was not working (which is why I asked about it's deployment status) and I looked into why today.

I was mistaken about the returned value from `insert`. [If no `returning` argument is provided](https://knexjs.org/#Builder-insert), it appears to return some `Result` object that has no actual info about the inserted rows, contrary to what I thought was happening.

<details>
<summary>Result object per local testing</summary>

```
Result {
  command: 'INSERT',
  rowCount: 1,
  oid: 0,
  rows: [],
  fields: [],
  _parsers: undefined,
  _types: TypeOverrides {
    _types: {
      getTypeParser: [Function: getTypeParser],
      setTypeParser: [Function: setTypeParser],
      arrayParser: [Object],
      builtins: [Object]
    },
    text: {},
    binary: {}
  },
  RowCtor: null,
  rowAsArray: false
}
```
</details>


So as it is currently, `rows[0]` is just `undefined`, and this route continues to return nothing to this day. :(

With this change the promise will return an array of inserted rows as objects with the `hook_id` property. The endpoint will then return the singular object with the `hook_id` property.

