### PR TITLE
Added openapi friendly names for objects, fixed type bug

### DIFF
--- a/CONTRIBUTORS.js
+++ b/CONTRIBUTORS.js
@@ -26,4 +26,5 @@ module.exports = {
   115074332: {}, // Sheemap
   94620402: {}, // lmmfranco
   193480093: {}, // angary
+  83615933: {}, // kshammer
 };

--- a/routes/objects.js
+++ b/routes/objects.js
@@ -1,4 +1,5 @@
 const teamObject = {
+  title: 'TeamObjectResponse',
   type: 'object',
   properties: {
     team_id: {
@@ -32,6 +33,7 @@ const teamObject = {
   },
 };
 const matchObject = {
+  title: 'MatchObjectResponse',
   type: 'object',
   properties: {
     match_id: {
@@ -97,6 +99,7 @@ const matchObject = {
   },
 };
 const heroObject = {
+  title: 'HeroObjectResponse',
   type: 'object',
   properties: {
     id: {
@@ -131,6 +134,7 @@ const heroObject = {
 const playerObject = {
   type: 'array',
   items: {
+    title: 'PlayerObjectResponse',
     type: 'object',
     properties: {
       account_id: {
@@ -225,6 +229,7 @@ const playerObject = {
 const leagueObject = {
   type: 'array',
   items: {
+    title: 'LeagueObjectResponse',
     type: 'object',
     properties: {
       leagueid: {

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1024,11 +1024,11 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 },
                 solo_competitive_rank: {
                   description: 'solo_competitive_rank',
-                  type: 'string',
+                  type: 'integer',
                 },
                 competitive_rank: {
                   description: 'competitive_rank',
-                  type: 'string',
+                  type: 'integer',
                 },
                 rank_tier: {
                   description: 'rank_tier',


### PR DESCRIPTION
The /players/{account_id} definition has the competitve_rank and solo_rank listed as strings but in the actual api response they are numbers. 

Reference https://api.opendota.com/api/players/83615933 

Wasn't sure whether to categorize them as numbers or integers as in the /players/{account_id}/ratings api def they are listed as integers but all other numbers in the /players/{account_id} response they are listed as numbers. 

