### PR TITLE
fix average medal calculation

### DIFF
--- a/store/queries.js
+++ b/store/queries.js
@@ -18,7 +18,7 @@ const cacheFunctions = require('./cacheFunctions');
 const benchmarksUtil = require('../util/benchmarksUtil');
 
 const {
-  redisCount, convert64to32, serialize, deserialize, isRadiant, isContributor, countItemPopularity,
+  redisCount, convert64to32, serialize, deserialize, isRadiant, isContributor, countItemPopularity, averageMedal
 } = utility;
 const { computeMatchData } = compute;
 const columnInfo = {};
@@ -488,7 +488,7 @@ function getMatchRankTier(match, cb) {
     }
     // Remove undefined/null values
     const filt = result.filter(r => r);
-    const avg = Math.floor(filt.map(r => Number(r)).reduce((a, b) => a + b, 0) / filt.length) || null;
+    const avg = averageMedal(filt.map(r => Number(r))) || null;
     return cb(err, avg, filt.length);
   });
 }

--- a/util/utility.js
+++ b/util/utility.js
@@ -448,6 +448,20 @@ function average(data) {
 }
 
 /**
+ * Finds the average rank medal of input array
+ * */
+function averageMedal(values) {
+  let medalSum = 0;
+  let starSum = 0;
+  values.forEach((value) => {
+    medalSum += Number(String(value)[0]);
+    starSum += value % 10;
+  });
+  const len = values.length;
+  return Math.round(medalSum / len) * 10 + Math.round(starSum / len);
+}
+
+/**
  * Finds the standard deviation of the input array
  * */
 function stdDev(data) {
@@ -846,6 +860,7 @@ module.exports = {
   getStartOfBlockMinutes,
   getEndOfMonth,
   average,
+  averageMedal,
   stdDev,
   median,
   deserialize,

--- a/util/utility.js
+++ b/util/utility.js
@@ -457,8 +457,8 @@ function averageMedal(values) {
     medalSum += Number(String(value)[0]);
     starSum += value % 10;
   });
-  const len = values.length;
-  return Math.round(medalSum / len) * 10 + Math.round(starSum / len);
+  const avgStars = (medalSum * 5 + starSum) / values.length;
+  return Math.floor(avgStars / 5) * 10 + Math.round(avgStars % 5);
 }
 
 /**

--- a/util/utility.js
+++ b/util/utility.js
@@ -451,13 +451,8 @@ function average(data) {
  * Finds the average rank medal of input array
  * */
 function averageMedal(values) {
-  let medalSum = 0;
-  let starSum = 0;
-  values.forEach((value) => {
-    medalSum += Number(String(value)[0]);
-    starSum += value % 10;
-  });
-  const avgStars = (medalSum * 5 + starSum) / values.length;
+  const numStars = values.map(value => Number(String(value)[0]) * 5 + (value % 10));
+  const avgStars = numStars.reduce((a, b) => a + b, 0) / numStars.length;
   return Math.floor(avgStars / 5) * 10 + Math.round(avgStars % 5);
 }
 


### PR DESCRIPTION
The old average rank function was made for mmr, so it didn't account for medal algebra, causing ranks such as Guardian 8 to appear.