### PR TITLE
Additional documentation for '/players/{account_id}/matches'

### DIFF
--- a/routes/params.js
+++ b/routes/params.js
@@ -57,9 +57,14 @@ module.exports = {
   projectParam: {
     name: 'project',
     in: 'query',
-    description: 'Fields to project (array)',
+    description: 'Fields to include in the returned matches',
     required: false,
-    type: 'string',
+    type: 'array',
+    collectionFormat: 'multi',
+    items: {
+      type: 'enum',
+      enum: ['account_id','match_id','player_slot','heroes','radiant_win','start_time','duration','cluster','region','patch','lobby_type','game_mode','level','kills','deaths','assists','kda','last_hits','denies','hero_damage','tower_damage','hero_healing','gold_per_min','xp_per_min','hero_id','leaver_status','version','courier_kills','tower_kills','neutral_kills','lane','lane_role','is_roaming','obs','sen','item_uses','purchase_time','item_usage','item_win','purchase','multi_kills','kill_streaks','all_word_counts','my_word_counts','throw','comeback','stomp','loss','actions_per_min','purchase_ward_observer','purchase_ward_sentry','purchase_tpscroll','purchase_rapier','purchase_gem','pings','stuns','lane_efficiency_pct','skill','party_size','item_0','item_1','item_2','item_3','item_4','item_5','item_neutral']
+    }
   },
   winParam: {
     name: 'win',


### PR DESCRIPTION
Hey! I've been using the api for a while and this particular endpoint `/players/{account_id}/matches` has been lacking some important documentation. This is just an update to the swagger api documentation to make it a lot more clear how to use the `project` field for this endpoint. I wasn't able to get my docker to behave properly to run odota core but I made these changes to the swagger api json file and tested it using odota/docs, and it looks much more usable now (see below). I'm pretty sure this doesn't affect any of the api functionality but again I wasn't able to test that. Let me know if you want me to make any changes!

[Endpoint Documentation](https://docs.opendota.com/index.html#tag/players%2Fpaths%2F~1players~1%7Baccount_id%7D~1matches%2Fget)
Before:
![image](https://user-images.githubusercontent.com/3231343/190835953-a26dd9e1-e30b-4738-b0ec-2a4420218e0f.png)
After:
![image](https://user-images.githubusercontent.com/3231343/190835968-de14342c-a13a-413f-907c-36ebfdbbc659.png)