### PR TITLE
Update courier death event

### DIFF
--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -480,11 +480,20 @@ function processExpand(entries, meta) {
       });
     },
     CHAT_MESSAGE_COURIER_LOST(e) {
-      // player1 = team that lost courier? (2/3)
+      // For backwards compatability - when teams only had one courier player1 would be the team
+      let team;
+      if (e.player2 === undefined) {
+        team = e.player1;
+      } else {
+        // 2 is radiant and 3 dire
+        team = (e.player1 < 5) ? 2 : 3;
+      }
       expand({
         time: e.time,
         type: e.type,
-        team: e.player1,
+        killer: e.player1,
+        owner: e.player2,
+        team,
       });
     },
     CHAT_MESSAGE_HERO_NOMINATED_BAN() {

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -480,19 +480,28 @@ function processExpand(entries, meta) {
       });
     },
     CHAT_MESSAGE_COURIER_LOST(e) {
-      // For backwards compatability - when teams only had one courier player1 would be the team
       let team;
+      let killer;
+      // For backwards compatability - when teams only had one courier player1 would be the team of killed courier
       if (e.player2 === undefined) {
         team = e.player1;
+        killer = null;
       } else {
         // 2 is radiant and 3 dire
-        team = (e.player1 < 5) ? 2 : 3;
+        team = e.player2;
+        if (e.player1 > -1) {
+          // 128 - 5 slot for dire killers
+          killer = (team === 3 ? 0 : 123) + e.player1;
+        }
+        if (e.player1 === -1) {
+          killer = -1;
+        }
       }
       expand({
         time: e.time,
         type: e.type,
-        killer: e.player1,
-        owner: e.player2,
+        value: e.value,
+        killer,
         team,
       });
     },

--- a/processors/processExpand.js
+++ b/processors/processExpand.js
@@ -490,8 +490,7 @@ function processExpand(entries, meta) {
         // 2 is radiant and 3 dire
         team = e.player2;
         if (e.player1 > -1) {
-          // 128 - 5 slot for dire killers
-          killer = (team === 3 ? 0 : 123) + e.player1;
+          killer = meta.slot_to_playerslot[e.player1];
         }
         if (e.player1 === -1) {
           killer = -1;


### PR DESCRIPTION
This PR fixes the incorrect team value in the `CHAT_MESSAGE_COURIER_LOST` lost event and adds killer and gold bounty information.

### Background

Before patch 7.23 (released 2019-11-26), each team only had one courier. The chat event would report `player1` property as the owner team of the courier, 2 for radiant and 3 for dire.

When each player got their own courier, the team property changed to `player2` with `player1` containing the slot of the killer, 0-4 for radiant and 5-9 for dire. For creep/tower killer the value is -1.

---
Related issues: https://github.com/odota/web/issues/3010, https://github.com/odota/web/issues/2778, https://github.com/odota/web/issues/2723, https://github.com/odota/web/issues/2443