### PR TITLE
Fix Swagger Spec definitions

### DIFF
--- a/routes/objects.js
+++ b/routes/objects.js
@@ -240,14 +240,17 @@ const leagueObject = {
       ticket: {
         description: "ticket",
         type: "string",
+        nullable: "true",
       },
       banner: {
         description: "banner",
         type: "string",
+        nullable: "true",
       },
       tier: {
         description: "tier",
         type: "string",
+        nullable: "true",
       },
       name: {
         description: "name",

--- a/routes/properties.js
+++ b/routes/properties.js
@@ -2,6 +2,7 @@ module.exports = {
   radiant_win: {
     description: "Boolean indicating whether Radiant won the match",
     type: "boolean",
+    nullable: true,
   },
   player_slot: {
     description:

--- a/routes/properties.js
+++ b/routes/properties.js
@@ -7,6 +7,7 @@ module.exports = {
     description:
       "Which slot the player is in. 0-127 are Radiant, 128-255 are Dire",
     type: "integer",
+    nullable: true,
   },
   duration: {
     description: "Duration of the game in seconds",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -2538,7 +2538,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 properties: {
                   hero_id: {
                     description: "The ID value of the hero played",
-                    type: "string",
+                    type: "integer",
                   },
                   score: {
                     description: "hero_score",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1153,23 +1153,26 @@ You can find data that can be used to convert hero and ability IDs and other inf
             description: "Success",
             schema: {
               title: "PlayersByRankResponse",
-              type: "object",
-              properties: {
-                account_id: {
-                  description: "account_id",
-                  type: "number",
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  account_id: {
+                    description: "account_id",
+                    type: "number",
+                  },
+                  rank_tier: {
+                    description:
+                      "Integer indicating the rank/medal of the player",
+                    type: "number",
+                  },
+                  fh_unavailable: {
+                    description:
+                      "Indicates if we were unable to fetch full history for this player due to privacy settings",
+                    type: "boolean",
+                  },
                 },
-                rank_tier: {
-                  description:
-                    "Integer indicating the rank/medal of the player",
-                  type: "number",
-                },
-                fh_unavailable: {
-                  description:
-                    "Indicates if we were unable to fetch full history for this player due to privacy settings",
-                  type: "boolean",
-                },
-              },
+              }
             },
           },
         },
@@ -2459,7 +2462,6 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   competitive_rank: {
                     description: "competitive_rank",
                     type: "integer",
-                    nullable: true,
                   },
                   time: {
                     description: "time",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -806,6 +806,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                       personaname: {
                         description: "personaname",
                         type: "string",
+                        nullable: true,
                       },
                       name: {
                         description: "name",
@@ -1234,6 +1235,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     personaname: {
                       description: "personaname",
                       type: "string",
+                      nullable: true,
                     },
                     name: {
                       description: "name",
@@ -1247,26 +1249,32 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     cheese: {
                       description: "cheese",
                       type: "integer",
+                      nullable: true,
                     },
                     steamid: {
                       description: "steamid",
                       type: "string",
+                      nullable: true,
                     },
                     avatar: {
                       description: "avatar",
                       type: "string",
+                      nullable: true,
                     },
                     avatarmedium: {
                       description: "avatarmedium",
                       type: "string",
+                      nullable: true,
                     },
                     avatarfull: {
                       description: "avatarfull",
                       type: "string",
+                      nullable: true,
                     },
                     profileurl: {
                       description: "profileurl",
                       type: "string",
+                      nullable: true,
                     },
                     last_login: {
                       description: "last_login",
@@ -1276,6 +1284,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     loccountrycode: {
                       description: "loccountrycode",
                       type: "string",
+                      nullable: true,
                     },
                     is_contributor: {
                       description:
@@ -1882,6 +1891,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   personaname: {
                     description: "personaname",
                     type: "string",
+                    nullable: true,
                   },
                   name: {
                     description: "name",
@@ -1903,10 +1913,12 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   avatar: {
                     description: "avatar",
                     type: "string",
+                    nullable: true,
                   },
                   avatarfull: {
                     description: "avatarfull",
                     type: "string",
+                    nullable: true,
                   },
                 },
               },
@@ -1987,10 +1999,12 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   team_name: {
                     description: "team_name",
                     type: "string",
+                    nullable: true,
                   },
                   team_tag: {
                     description: "team_tag",
                     type: "string",
+                    nullable: true,
                   },
                   is_locked: {
                     description: "is_locked",
@@ -2012,18 +2026,22 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   avatar: {
                     description: "avatar",
                     type: "string",
+                    nullable: true,
                   },
                   avatarmedium: {
                     description: "avatarmedium",
                     type: "string",
+                    nullable: true,
                   },
                   avatarfull: {
                     description: "avatarfull",
                     type: "string",
+                    nullable: true,
                   },
                   profileurl: {
                     description: "profileurl",
                     type: "string",
+                    nullable: true,
                   },
                   last_login: {
                     description: "last_login",
@@ -2035,22 +2053,27 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     description: "full_history_time",
                     type: "string",
                     format: "date-time",
+                    nullable: true,
                   },
                   cheese: {
                     description: "cheese",
                     type: "integer",
+                    nullable: true,
                   },
                   fh_unavailable: {
                     description: "fh_unavailable",
                     type: "boolean",
+                    nullable: true,
                   },
                   loccountrycode: {
                     description: "loccountrycode",
                     type: "string",
+                    nullable: true,
                   },
                   last_played: {
                     description: "last_played",
                     type: "integer",
+                    nullable: true,
                   },
                   win: {
                     description: "win",
@@ -3076,6 +3099,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                           loccountrycode: {
                             description: "loccountrycode",
                             type: "string",
+                            nullable: true,
                           },
                           count: {
                             description: "count",
@@ -3180,10 +3204,12 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   avatarfull: {
                     description: "avatarfull",
                     type: "string",
+                    nullable: true,
                   },
                   personaname: {
                     description: "personaname",
                     type: "string",
+                    nullable: true,
                   },
                   last_match_time: {
                     description: "last_match_time. May not be present or null.",
@@ -3268,22 +3294,27 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     avatar: {
                       description: "avatar",
                       type: "string",
+                      nullable: true,
                     },
                     avatarmedium: {
                       description: "avatarmedium",
                       type: "string",
+                      nullable: true,
                     },
                     avatarfull: {
                       description: "avatarfull",
                       type: "string",
+                      nullable: true,
                     },
                     profileurl: {
                       description: "profileurl",
                       type: "string",
+                      nullable: true,
                     },
                     personaname: {
                       description: "personaname",
                       type: "string",
+                      nullable: true,
                     },
                     last_login: {
                       description: "last_login",
@@ -3299,18 +3330,22 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     cheese: {
                       description: "cheese",
                       type: "integer",
+                      nullable: true,
                     },
                     fh_unavailable: {
                       description: "fh_unavailable",
                       type: "boolean",
+                      nullable: true,
                     },
                     loccountrycode: {
                       description: "loccountrycode",
                       type: "string",
+                      nullable: true,
                     },
                     rank_tier: {
                       description: "rank_tier",
                       type: "integer",
+                      nullable: true,
                     },
                   },
                 },
@@ -4471,6 +4506,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 opposing_team_name: {
                   description: "Opposing team name, e.g. 'Evil Geniuses'",
                   type: "string",
+                  nullable: true,
                 },
                 opposing_team_logo: {
                   description: "Opposing team logo url",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -5100,10 +5100,29 @@ You can find data that can be used to convert hero and ability IDs and other inf
           200: {
             description: "Success",
             schema: {
-              type: "object",
-              additionalProperties: {
-                title: "ConstantResourceResponse",
-              },
+              oneOf: [
+                {
+                  type: "object",
+                  additionalProperties: {
+                    title: "ConstantResourceResponse",
+                  },
+                },
+                {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    additionalProperties: {
+                      title: "ConstantResourceResponse",
+                    },
+                  },
+                },
+                {
+                  type: "array",
+                  items: {
+                    type: "integer",
+                  },
+                },
+              ],
             },
           },
         },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1271,6 +1271,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     last_login: {
                       description: "last_login",
                       type: "string",
+                      nullable: true,
                     },
                     loccountrycode: {
                       description: "loccountrycode",
@@ -1897,6 +1898,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   last_login: {
                     description: "last_login",
                     type: "string",
+                    nullable: true,
                   },
                   avatar: {
                     description: "avatar",
@@ -2026,6 +2028,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     description: "last_login",
                     type: "string",
                     format: "date-time",
+                    nullable: true,
                   },
                   full_history_time: {
                     description: "full_history_time",
@@ -3285,6 +3288,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                       description: "last_login",
                       type: "string",
                       format: "date-time",
+                      nullable: true,
                     },
                     full_history_time: {
                       description: "full_history_time",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -249,7 +249,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   type: "array",
                   items: {
                     type: "object",
-                  }
+                  },
                 },
                 picks_bans: {
                   description:
@@ -257,7 +257,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   type: "array",
                   items: {
                     type: "object",
-                  }
+                  },
                 },
                 positive_votes: {
                   description:
@@ -270,7 +270,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   type: "array",
                   items: {
                     type: "number",
-                  }
+                  },
                 },
                 radiant_score: {
                   description:
@@ -284,7 +284,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   type: "array",
                   items: {
                     type: "number",
-                  }
+                  },
                 },
                 start_time: {
                   description: "The Unix timestamp at which the game started",
@@ -297,8 +297,8 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     type:"array",
                     items:{
                       type:"object",
-                    }
-                  }
+                    },
+                  },
                 },
                 tower_status_dire: {
                   description:
@@ -390,11 +390,11 @@ You can find data that can be used to convert hero and ability IDs and other inf
                       additional_units: {
                         description:
                           "Object containing information on additional units the player had under their control",
-                          type: "array",
-                          items:{
-                            type: "object",
-                          },
-                          nullable: true,
+                        type: "array",
+                        items:{
+                          type: "object",
+                        },
+                        nullable: true,
                       },
                       assists: {
                         description: "Number of assists the player had",
@@ -1023,7 +1023,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                             creation_date: {
                               type: "string",
                               format: "date-time",
-                              nullable: true
+                              nullable: true,
                             },
                             image_inventory: {
                               type: "string",
@@ -1051,9 +1051,9 @@ You can find data that can be used to convert hero and ability IDs and other inf
                             used_by_heroes: {
                               type: "string",
                               nullable: true,
-                            }
-                          }
-                        }
+                            },
+                          },
+                        },
                       },
                       benchmarks: {
                         description:
@@ -1174,7 +1174,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     nullable: true,
                   },
                 },
-              }
+              },
             },
           },
         },
@@ -3725,8 +3725,8 @@ You can find data that can be used to convert hero and ability IDs and other inf
               type: "array",
               items: {
                 type: "integer",
-              }
-            }
+              },
+            },
           },
           {
             name: "teamB",
@@ -3739,8 +3739,8 @@ You can find data that can be used to convert hero and ability IDs and other inf
               type: "array",
               items: {
                 type: "integer",
-              }
-            }
+              },
+            },
           },
         ],
         responses: {
@@ -3751,9 +3751,9 @@ You can find data that can be used to convert hero and ability IDs and other inf
               type: "array",
               items: {
                 type: "object",
-              }
-            }
-          }
+              },
+            },
+          },
         },
         route: () => "/findMatches",
         func: (req, res, cb) => {

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -3628,6 +3628,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 type: "object",
               }
             }
+          }
         },
         route: () => "/findMatches",
         func: (req, res, cb) => {

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -988,7 +988,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                       purchase_tpscroll: {
                         description:
                           "Total number of TP scrolls purchased by the player",
-                        type: "object",
+                          type: "integer",
                       },
                       actions_per_min: {
                         description: "Actions per minute",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -243,12 +243,18 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 },
                 objectives: {
                   description: "objectives",
-                  type: "object",
+                  type: "array",
+                  items: {
+                    type: "object",
+                  }
                 },
                 picks_bans: {
                   description:
                     "Object containing information on the draft. Each pick/ban contains a boolean relating to whether the choice is a pick or a ban, the hero ID, the team the picked or banned it, and the order.",
-                  type: "object",
+                    type: "array",
+                    items: {
+                      type: "object",
+                    }
                 },
                 positive_votes: {
                   description:
@@ -258,7 +264,10 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 radiant_gold_adv: {
                   description:
                     "Array of the Radiant gold advantage at each minute in the game. A negative number means that Radiant is behind, and thus it is their gold disadvantage. ",
-                  type: "object",
+                  type: "array",
+                  items: {
+                    type: "number",
+                  }
                 },
                 radiant_score: {
                   description:
@@ -269,7 +278,10 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 radiant_xp_adv: {
                   description:
                     "Array of the Radiant experience advantage at each minute in the game. A negative number means that Radiant is behind, and thus it is their experience disadvantage. ",
-                  type: "object",
+                  type: "array",
+                  items: {
+                    type: "number",
+                  }
                 },
                 start_time: {
                   description: "The Unix timestamp at which the game started",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -2856,7 +2856,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                           },
                           dataTypeModifier: {
                             description: "dataTypeModifier",
-                            type: "string",
+                            type: "integer",
                           },
                           format: {
                             description: "format",
@@ -2946,7 +2946,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                           },
                           dataTypeModifier: {
                             description: "dataTypeModifier",
-                            type: "string",
+                            type: "integer",
                           },
                           format: {
                             description: "format",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -3594,14 +3594,28 @@ You can find data that can be used to convert hero and ability IDs and other inf
             in: "query",
             description: "Hero IDs on first team (array)",
             required: false,
-            type: "integer",
+            style: "form",
+            explode: false,
+            schema: {
+              type: "array",
+              items: {
+                type: "integer"
+              }
+            }
           },
           {
             name: "teamB",
             in: "query",
             description: "Hero IDs on second team (array)",
             required: false,
-            type: "integer",
+            style: "form",
+            explode: false,
+            schema: {
+              type: "array",
+              items: {
+                type: "integer"
+              }
+            }
           },
         ],
         responses: {
@@ -3609,9 +3623,11 @@ You can find data that can be used to convert hero and ability IDs and other inf
             description: "Success",
             schema: {
               title: "FindMatchesResponse",
-              type: "object",
-            },
-          },
+              type: "array",
+              items: {
+                type: "object"
+              }
+            }
         },
         route: () => "/findMatches",
         func: (req, res, cb) => {

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -254,10 +254,10 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 picks_bans: {
                   description:
                     "Object containing information on the draft. Each pick/ban contains a boolean relating to whether the choice is a pick or a ban, the hero ID, the team the picked or banned it, and the order.",
-                    type: "array",
-                    items: {
-                      type: "object",
-                    }
+                  type: "array",
+                  items: {
+                    type: "object",
+                  }
                 },
                 positive_votes: {
                   description:

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1191,18 +1191,22 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 solo_competitive_rank: {
                   description: "solo_competitive_rank",
                   type: "integer",
+                  nullable: true,
                 },
                 competitive_rank: {
                   description: "competitive_rank",
                   type: "integer",
+                  nullable: true,
                 },
                 rank_tier: {
                   description: "rank_tier",
                   type: "number",
+                  nullable: true,
                 },
                 leaderboard_rank: {
                   description: "leaderboard_rank",
                   type: "number",
+                  nullable: true,
                 },
                 mmr_estimate: {
                   description: "mmr_estimate",
@@ -1211,6 +1215,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     estimate: {
                       description: "estimate",
                       type: "number",
+                      nullable: true,
                     },
                   },
                 },
@@ -2449,10 +2454,12 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   solo_competitive_rank: {
                     description: "solo_competitive_rank",
                     type: "integer",
+                    nullable: true,
                   },
                   competitive_rank: {
                     description: "competitive_rank",
                     type: "integer",
+                    nullable: true,
                   },
                   time: {
                     description: "time",
@@ -2832,6 +2839,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 banner: {
                   description: "banner",
                   type: "object",
+                  nullable: true,
                 },
               },
             },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -3599,7 +3599,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
             schema: {
               type: "array",
               items: {
-                type: "integer"
+                type: "integer",
               }
             }
           },
@@ -3613,7 +3613,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
             schema: {
               type: "array",
               items: {
-                type: "integer"
+                type: "integer",
               }
             }
           },
@@ -3625,7 +3625,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
               title: "FindMatchesResponse",
               type: "array",
               items: {
-                type: "object"
+                type: "object",
               }
             }
         },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -3278,82 +3278,85 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 },
                 rankings: {
                   description: "rankings",
-                  type: "object",
-                  properties: {
-                    account_id: {
-                      description: "account_id",
-                      type: "integer",
-                    },
-                    score: {
-                      description: "score",
-                      type: "string",
-                    },
-                    steamid: {
-                      description: "steamid",
-                      type: "string",
-                      nullable: true,
-                    },
-                    avatar: {
-                      description: "avatar",
-                      type: "string",
-                      nullable: true,
-                    },
-                    avatarmedium: {
-                      description: "avatarmedium",
-                      type: "string",
-                      nullable: true,
-                    },
-                    avatarfull: {
-                      description: "avatarfull",
-                      type: "string",
-                      nullable: true,
-                    },
-                    profileurl: {
-                      description: "profileurl",
-                      type: "string",
-                      nullable: true,
-                    },
-                    personaname: {
-                      description: "personaname",
-                      type: "string",
-                      nullable: true,
-                    },
-                    last_login: {
-                      description: "last_login",
-                      type: "string",
-                      format: "date-time",
-                      nullable: true,
-                    },
-                    full_history_time: {
-                      description: "full_history_time",
-                      type: "string",
-                      format: "date-time",
-                    },
-                    cheese: {
-                      description: "cheese",
-                      type: "integer",
-                      nullable: true,
-                    },
-                    fh_unavailable: {
-                      description: "fh_unavailable",
-                      type: "boolean",
-                      nullable: true,
-                    },
-                    loccountrycode: {
-                      description: "loccountrycode",
-                      type: "string",
-                      nullable: true,
-                    },
-                    rank_tier: {
-                      description: "rank_tier",
-                      type: "integer",
-                      nullable: true,
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      account_id: {
+                        description: "account_id",
+                        type: "integer",
+                      },
+                      score: {
+                        description: "score",
+                        type: "number",
+                      },
+                      steamid: {
+                        description: "steamid",
+                        type: "string",
+                        nullable: true,
+                      },
+                      avatar: {
+                        description: "avatar",
+                        type: "string",
+                        nullable: true,
+                      },
+                      avatarmedium: {
+                        description: "avatarmedium",
+                        type: "string",
+                        nullable: true,
+                      },
+                      avatarfull: {
+                        description: "avatarfull",
+                        type: "string",
+                        nullable: true,
+                      },
+                      profileurl: {
+                        description: "profileurl",
+                        type: "string",
+                        nullable: true,
+                      },
+                      personaname: {
+                        description: "personaname",
+                        type: "string",
+                        nullable: true,
+                      },
+                      last_login: {
+                        description: "last_login",
+                        type: "string",
+                        format: "date-time",
+                        nullable: true,
+                      },
+                      full_history_time: {
+                        description: "full_history_time",
+                        type: "string",
+                        format: "date-time",
+                      },
+                      cheese: {
+                        description: "cheese",
+                        type: "integer",
+                        nullable: true,
+                      },
+                      fh_unavailable: {
+                        description: "fh_unavailable",
+                        type: "boolean",
+                        nullable: true,
+                      },
+                      loccountrycode: {
+                        description: "loccountrycode",
+                        type: "string",
+                        nullable: true,
+                      },
+                      rank_tier: {
+                        description: "rank_tier",
+                        type: "integer",
+                        nullable: true,
+                      },
                     },
                   },
                 },
               },
             },
-          },
+          }
         },
         route: () => "/rankings",
         func: (req, res, cb) => {

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -3290,7 +3290,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                           },
                           value: {
                             description: "value",
-                            type: "integer",
+                            type: "number",
                           },
                         },
                       },
@@ -3306,7 +3306,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                           },
                           value: {
                             description: "value",
-                            type: "integer",
+                            type: "number",
                           },
                         },
                       },
@@ -3322,7 +3322,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                           },
                           value: {
                             description: "value",
-                            type: "integer",
+                            type: "number",
                           },
                         },
                       },
@@ -3338,7 +3338,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                           },
                           value: {
                             description: "value",
-                            type: "integer",
+                            type: "number",
                           },
                         },
                       },
@@ -3354,7 +3354,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                           },
                           value: {
                             description: "value",
-                            type: "integer",
+                            type: "number",
                           },
                         },
                       },
@@ -3370,7 +3370,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                           },
                           value: {
                             description: "value",
-                            type: "integer",
+                            type: "number",
                           },
                         },
                       },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -811,6 +811,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                       name: {
                         description: "name",
                         type: "string",
+                        nullable: true,
                       },
                       last_login: {
                         description: "Time of player's last login",
@@ -1240,6 +1241,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     name: {
                       description: "name",
                       type: "string",
+                      nullable: true,
                     },
                     plus: {
                       description:
@@ -1634,6 +1636,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   version: {
                     description: "version",
                     type: "integer",
+                    nullable: true,
                   },
                   kills: {
                     description:
@@ -1654,11 +1657,13 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     description:
                       "Skill bracket assigned by Valve (Normal, High, Very High)",
                     type: "integer",
+                    nullable: true,
                   },
                   average_rank: {
                     description:
                       "Average rank of players with public match data",
                     type: "integer",
+                    nullable: true,
                   },
                   leaver_status: {
                     description:
@@ -1668,6 +1673,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   party_size: {
                     description: "Size of the player's party",
                     type: "integer",
+                    nullable: true,
                   },
                 },
               },
@@ -1896,6 +1902,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   name: {
                     description: "name",
                     type: "string",
+                    nullable: true,
                   },
                   is_contributor: {
                     description: "is_contributor",
@@ -2103,10 +2110,12 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   with_gpm_sum: {
                     description: "with_gpm_sum",
                     type: "integer",
+                    nullable: true,
                   },
                   with_xpm_sum: {
                     description: "with_xpm_sum",
                     type: "integer",
+                    nullable: true,
                   },
                 },
               },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -164,6 +164,9 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 cosmetics: {
                   description: "cosmetics",
                   type: "object",
+                  additionalProperties: {
+                    type: "integer",
+                  },
                 },
                 dire_score: {
                   description:

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -5100,8 +5100,8 @@ You can find data that can be used to convert hero and ability IDs and other inf
           200: {
             description: "Success",
             schema: {
-              type: "array",
-              items: {
+              type: "object",
+              additionalProperties: {
                 title: "ConstantResourceResponse",
               },
             },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -289,7 +289,13 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 },
                 teamfights: {
                   description: "teamfights",
-                  type: "object",
+                  type: "array",
+                  items:{
+                    type:"array",
+                    items:{
+                      type:"object",
+                    }
+                  }
                 },
                 tower_status_dire: {
                   description:

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -381,7 +381,11 @@ You can find data that can be used to convert hero and ability IDs and other inf
                       additional_units: {
                         description:
                           "Object containing information on additional units the player had under their control",
-                        type: "object",
+                          type: "array",
+                          items:{
+                            type: "object",
+                          },
+                          nullable: true,
                       },
                       assists: {
                         description: "Number of assists the player had",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -994,7 +994,50 @@ You can find data that can be used to convert hero and ability IDs and other inf
                         description: "cosmetics",
                         type: "array",
                         items: {
-                          type: "integer",
+                          type: "object",
+                          properties: {
+                            item_id: {
+                              type: "integer",
+                            },
+                            name: {
+                              type: "string",
+                            },
+                            prefab: {
+                              type: "string",
+                            },
+                            creation_date: {
+                              type: "string",
+                              format: "date-time",
+                              nullable: true
+                            },
+                            image_inventory: {
+                              type: "string",
+                              nullable: true,
+                            },
+                            image_path: {
+                              type: "string",
+                              nullable: true,
+                            },
+                            item_description: {
+                              type: "string",
+                              nullable: true,
+                            },
+                            item_name: {
+                              type: "string",
+                            },
+                            item_rarity: {
+                              type: "string",
+                              nullable: true,
+                            },
+                            item_type_name: {
+                              type: "string",
+                              nullable: true,
+                            },
+                            used_by_heroes: {
+                              type: "string",
+                              nullable: true,
+                            }
+                          }
                         },
                       },
                       benchmarks: {

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -2022,6 +2022,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   steamid: {
                     description: "steamid",
                     type: "string",
+                    nullable: true,
                   },
                   avatar: {
                     description: "avatar",
@@ -3290,6 +3291,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     steamid: {
                       description: "steamid",
                       type: "string",
+                      nullable: true,
                     },
                     avatar: {
                       description: "avatar",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -3356,7 +3356,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 },
               },
             },
-          }
+          },
         },
         route: () => "/rankings",
         func: (req, res, cb) => {

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1170,6 +1170,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     description:
                       "Indicates if we were unable to fetch full history for this player due to privacy settings",
                     type: "boolean",
+                    nullable: true,
                   },
                 },
               }

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1052,7 +1052,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                               nullable: true,
                             }
                           }
-                        },
+                        }
                       },
                       benchmarks: {
                         description:

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -2191,7 +2191,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   },
                   sum: {
                     description: "sum",
-                    type: "integer",
+                    type: "number",
                   },
                 },
               },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -990,7 +990,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                       purchase_tpscroll: {
                         description:
                           "Total number of TP scrolls purchased by the player",
-                          type: "integer",
+                        type: "integer",
                       },
                       actions_per_min: {
                         description: "Actions per minute",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -4762,19 +4762,19 @@ You can find data that can be used to convert hero and ability IDs and other inf
                 properties: {
                   match_id: {
                     description: "match_id",
-                    type: "integer",
+                    type: "string",
                   },
                   start_time: {
                     description: "start_time",
-                    type: "integer",
+                    type: "string",
                   },
                   hero_id: {
                     description: "The ID value of the hero played",
-                    type: "integer",
+                    type: "string",
                   },
                   score: {
                     description: "score",
-                    type: "number",
+                    type: "string",
                   },
                 },
               },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -100,7 +100,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
   },
   host: "api.opendota.com",
   basePath: "/api",
-  produces: ["application/json"],
+  produces: ["application/json; charset=utf-8"],
   paths: {
     "/matches/{match_id}": {
       get: {

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -2003,6 +2003,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   locked_until: {
                     description: "locked_until",
                     type: "integer",
+                    nullable: true,
                   },
                   steamid: {
                     description: "steamid",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -958,15 +958,18 @@ You can find data that can be used to convert hero and ability IDs and other inf
                         description:
                           "Integer referring to which lane the hero laned in",
                         type: "integer",
+                        nullable: true,
                       },
                       lane_role: {
                         description: "lane_role",
                         type: "integer",
+                        nullable: true,
                       },
                       is_roaming: {
                         description:
                           "Boolean referring to whether or not the player roamed",
                         type: "boolean",
+                        nullable: true,
                       },
                       purchase_time: {
                         description:
@@ -1468,6 +1471,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                   version: {
                     description: "version",
                     type: "integer",
+                    nullable: true,
                   },
                   kills: {
                     description:
@@ -1488,11 +1492,13 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     description:
                       "Skill bracket assigned by Valve (Normal, High, Very High). If the skill is unknown, will return null.",
                     type: "integer",
+                    nullable: true,
                   },
                   average_rank: {
                     description:
                       "Average rank of players with public match data",
                     type: "integer",
+                    nullable: true,
                   },
                   xp_per_min: {
                     description: "Experience Per Minute obtained by the player",
@@ -1519,15 +1525,18 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     description:
                       "Integer corresponding to which lane the player laned in for the match",
                     type: "integer",
+                    nullable: true,
                   },
                   lane_role: {
                     description: "lane_role",
                     type: "integer",
+                    nullable: true,
                   },
                   is_roaming: {
                     description:
                       "Boolean describing whether or not the player roamed",
                     type: "boolean",
+                    nullable: true,
                   },
                   cluster: {
                     description: "cluster",
@@ -1542,6 +1551,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                     description:
                       "Size of the players party. If not in a party, will return 1.",
                     type: "integer",
+                    nullable: true,
                   },
                 },
               },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -815,6 +815,7 @@ You can find data that can be used to convert hero and ability IDs and other inf
                         description: "Time of player's last login",
                         type: "string",
                         format: "date-time",
+                        nullable: true,
                       },
                       radiant_win: properties.radiant_win,
                       start_time: {


### PR DESCRIPTION
Very simple fix - in /benchmarks there are decimal values that are currently typed as integers.

Edit: Fixing more types. Log of changes:
- benchmark metrics from integer to number
- distributions: `dataTypeModifier` from string to integer
- findMatches: input types for teamA and teamB were integers, now array of integers. response type now correct as array
- leagueObject properties should be nullable
- matches required the most updates... summary:
 
- - player_slot property is nullable
- - objectives, picks_bans, gold_adv and xp_adv are arrays
- - expand cosmetics with item properties
- - additional units is an array and nullable
- - teamfights is a nested array
- - cosmetics here are integers (there are two fields named cosmetics in /matches response, just different nesting)
- - tpscrolls is an integer
- - last_login is nullable
- nullable fields in players response
- so many nullable fields
- rankings responds with an array; score is a number
- NB: RecordsResponse -- server responds with strings; should be fixed serverside and types reverted to integers, in order to be consistent with other match id responses
- NB: content type is `application/json; charset=utf-8`, previously just `application/json`
- `/constants/{resource}` response can be oneOf 3 different types
- managed to get all `/constants/{resource}` and `/players/{account_id}/{field}` paths to succeed
