### PR TITLE
Add `minRank` and `maxRank` query parameters to `/publicMatches`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opendota-core",
-  "version": "21.0.0",
+  "version": "21.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opendota-core",
-      "version": "21.0.0",
+      "version": "21.0.1",
       "license": "MIT",
       "dependencies": {
         "@elastic/elasticsearch": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendota-core",
   "description": "Open source Dota data platform",
-  "version": "21.0.0",
+  "version": "21.0.1",
   "license": "MIT",
   "main": "index.js",
   "scripts": {

--- a/routes/requests/queryParams/matchParams.js
+++ b/routes/requests/queryParams/matchParams.js
@@ -17,8 +17,8 @@ module.exports = {
       type: "integer",
     },
   },
-  minMmrParam: {
-    name: "min_mmr",
+  minRankParam: {
+    name: "min_rank",
     in: "query",
     description: "Minimum MMR for the matches",
     required: false,
@@ -26,8 +26,8 @@ module.exports = {
       type: "integer",
     },
   },
-  maxMmrParam: {
-    name: "max_mmr",
+  maxRankParam: {
+    name: "max_rank",
     in: "query",
     description: "Maximum MMR for the matches",
     required: false,

--- a/routes/requests/queryParams/matchParams.js
+++ b/routes/requests/queryParams/matchParams.js
@@ -17,6 +17,24 @@ module.exports = {
       type: "integer",
     },
   },
+  minMmrParam: {
+    name: "min_mmr",
+    in: "query",
+    description: "Minimum MMR for the matches",
+    required: false,
+    schema: {
+      type: "integer",
+    },
+  },
+  maxMmrParam: {
+    name: "max_mmr",
+    in: "query",
+    description: "Maximum MMR for the matches",
+    required: false,
+    schema: {
+      type: "integer",
+    },
+  },
   mmrAscendingParam: {
     name: "mmr_ascending",
     in: "query",

--- a/routes/requests/queryParams/matchParams.js
+++ b/routes/requests/queryParams/matchParams.js
@@ -8,6 +8,15 @@ module.exports = {
     },
   },
   // for /publicMatches:
+  lessThanMatchIdParam: {
+    name: "less_than_match_id",
+    in: "query",
+    description: "Get matches with a match ID lower than this value",
+    required: false,
+    schema: {
+      type: "integer",
+    },
+  },
   mmrAscendingParam: {
     name: "mmr_ascending",
     in: "query",
@@ -21,15 +30,6 @@ module.exports = {
     name: "mmr_descending",
     in: "query",
     description: "Order by MMR descending",
-    required: false,
-    schema: {
-      type: "integer",
-    },
-  },
-  lessThanMatchIdParam: {
-    name: "less_than_match_id",
-    in: "query",
-    description: "Get matches with a match ID lower than this value",
     required: false,
     schema: {
       type: "integer",

--- a/routes/requests/queryParams/matchParams.js
+++ b/routes/requests/queryParams/matchParams.js
@@ -20,7 +20,8 @@ module.exports = {
   minRankParam: {
     name: "min_rank",
     in: "query",
-    description: "Minimum MMR for the matches",
+    description:
+      "Minimum rank for the matches. Ranks are represented by integers (10-15: Herald, 20-25: Guardian, 30-35: Crusader, 40-45: Archon, 50-55: Legend, 60-65: Ancient, 70-75: Divine, 80-85: Immortal). Each increment represents an additional star.",
     required: false,
     schema: {
       type: "integer",
@@ -29,7 +30,8 @@ module.exports = {
   maxRankParam: {
     name: "max_rank",
     in: "query",
-    description: "Maximum MMR for the matches",
+    description:
+      "Maximum rank for the matches. Ranks are represented by integers (10-15: Herald, 20-25: Guardian, 30-35: Crusader, 40-45: Archon, 50-55: Legend, 60-65: Ancient, 70-75: Divine, 80-85: Immortal). Each increment represents an additional star.",
     required: false,
     schema: {
       type: "integer",

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1182,18 +1182,18 @@ const spec = {
           let moreThan = lessThan - 1000000;
           let order = "";
           if (req.query.mmr_ascending) {
-            order = "ORDER BY avg_mmr ASC NULLS LAST";
+            order = "ORDER BY avg_rank_tier ASC NULLS LAST";
           } else if (req.query.mmr_descending) {
-            order = "ORDER BY avg_mmr DESC NULLS LAST";
+            order = "ORDER BY avg_rank_tier DESC NULLS LAST";
           } else {
             order = "ORDER BY match_id DESC";
             moreThan = 0;
           }
           let minRank = req.query.min_rank
-            ? `AND avg_mmr >= ${req.query.min_mmr}`
+            ? `AND avg_rank_tier >= ${req.query.min_rank}`
             : "";
           let maxRank = req.query.max_rank
-            ? `AND avg_mmr <= ${req.query.max_mmr}`
+            ? `AND avg_rank_tier <= ${req.query.max_rank}`
             : "";
 
           db.raw(

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1153,6 +1153,7 @@ const spec = {
         description: "Get list of randomly sampled public matches",
         tags: ["public matches"],
         parameters: [
+          { $ref: "#/components/parameters/lessThanMatchIdParam" },
           { $ref: "#/components/parameters/mmrAscendingParam" },
           { $ref: "#/components/parameters/mmrDescendingParam" },
           { $ref: "#/components/parameters/lessThanMatchIdParam" },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1154,8 +1154,8 @@ const spec = {
         tags: ["public matches"],
         parameters: [
           { $ref: "#/components/parameters/lessThanMatchIdParam" },
-          { $ref: "#/components/parameters/minMmrParam" },
-          { $ref: "#/components/parameters/maxMmrParam" },
+          { $ref: "#/components/parameters/minRankParam" },
+          { $ref: "#/components/parameters/maxRankParam" },
           { $ref: "#/components/parameters/mmrAscendingParam" },
           { $ref: "#/components/parameters/mmrDescendingParam" },
         ],
@@ -1189,10 +1189,10 @@ const spec = {
             order = "ORDER BY match_id DESC";
             moreThan = 0;
           }
-          let minMmr = req.query.min_mmr
+          let minRank = req.query.min_rank
             ? `AND avg_mmr >= ${req.query.min_mmr}`
             : "";
-          let maxMmr = req.query.max_mmr
+          let maxRank = req.query.max_rank
             ? `AND avg_mmr <= ${req.query.max_mmr}`
             : "";
 
@@ -1202,8 +1202,8 @@ const spec = {
           WHERE TRUE
           AND match_id > ?
           AND match_id < ?
-          ${minMmr}
-          ${maxMmr}
+          ${minRank}
+          ${maxRank}
           ${order}
           LIMIT 100)
           SELECT * FROM

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1189,12 +1189,21 @@ const spec = {
             order = "ORDER BY match_id DESC";
             moreThan = 0;
           }
+          let minMmr = req.query.min_mmr
+            ? `AND avg_mmr >= ${req.query.min_mmr}`
+            : "";
+          let maxMmr = req.query.max_mmr
+            ? `AND avg_mmr <= ${req.query.max_mmr}`
+            : "";
+
           db.raw(
             `
           WITH match_ids AS (SELECT match_id FROM public_matches
           WHERE TRUE
           AND match_id > ?
           AND match_id < ?
+          ${minMmr}
+          ${maxMmr}
           ${order}
           LIMIT 100)
           SELECT * FROM

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -79,11 +79,11 @@ const spec = {
   info: {
     title: "OpenDota API",
     description: `# Introduction
-    The OpenDota API provides Dota 2 related data including advanced match data extracted from match replays.
-    
-    You can find data that can be used to convert hero and ability IDs and other information provided by the API from the [dotaconstants](https://github.com/odota/dotaconstants) repository.
-    
-    The OpenDota API offers 50,000 free calls per month and a rate limit of 60 requests/minute. We also offer a Premium Tier with unlimited API calls and higher rate limits. Check out the [API page](https://www.opendota.com/api-keys) to learn more.
+The OpenDota API provides Dota 2 related data including advanced match data extracted from match replays.
+
+You can find data that can be used to convert hero and ability IDs and other information provided by the API from the [dotaconstants](https://github.com/odota/dotaconstants) repository.
+
+The OpenDota API offers 50,000 free calls per month and a rate limit of 60 requests/minute. We also offer a Premium Tier with unlimited API calls and higher rate limits. Check out the [API page](https://www.opendota.com/api-keys) to learn more.
     `,
     version: packageJson.version,
   },

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1182,9 +1182,9 @@ const spec = {
           let moreThan = lessThan - 1000000;
           let order = "";
           if (req.query.mmr_ascending) {
-            order = "ORDER BY avg_rank_tier ASC NULLS LAST";
+            order = "ORDER BY avg_mmr ASC NULLS LAST";
           } else if (req.query.mmr_descending) {
-            order = "ORDER BY avg_rank_tier DESC NULLS LAST";
+            order = "ORDER BY avg_mmr DESC NULLS LAST";
           } else {
             order = "ORDER BY match_id DESC";
             moreThan = 0;

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1154,9 +1154,10 @@ const spec = {
         tags: ["public matches"],
         parameters: [
           { $ref: "#/components/parameters/lessThanMatchIdParam" },
+          { $ref: "#/components/parameters/minMmrParam" },
+          { $ref: "#/components/parameters/maxMmrParam" },
           { $ref: "#/components/parameters/mmrAscendingParam" },
           { $ref: "#/components/parameters/mmrDescendingParam" },
-          { $ref: "#/components/parameters/lessThanMatchIdParam" },
         ],
         responses: {
           200: {

--- a/spec.json
+++ b/spec.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "OpenDota API",
-    "description": "# Introduction\n    The OpenDota API provides Dota 2 related data including advanced match data extracted from match replays.\n    \n    You can find data that can be used to convert hero and ability IDs and other information provided by the API from the [dotaconstants](https://github.com/odota/dotaconstants) repository.\n    \n    The OpenDota API offers 50,000 free calls per month and a rate limit of 60 requests/minute. We also offer a Premium Tier with unlimited API calls and higher rate limits. Check out the [API page](https://www.opendota.com/api-keys) to learn more.\n    ",
+    "description": "# Introduction\nThe OpenDota API provides Dota 2 related data including advanced match data extracted from match replays.\n\nYou can find data that can be used to convert hero and ability IDs and other information provided by the API from the [dotaconstants](https://github.com/odota/dotaconstants) repository.\n\nThe OpenDota API offers 50,000 free calls per month and a rate limit of 60 requests/minute. We also offer a Premium Tier with unlimited API calls and higher rate limits. Check out the [API page](https://www.opendota.com/api-keys) to learn more.\n    ",
     "version": "21.0.1"
   },
   "servers": [

--- a/spec.json
+++ b/spec.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "OpenDota API",
     "description": "# Introduction\n    The OpenDota API provides Dota 2 related data including advanced match data extracted from match replays.\n    \n    You can find data that can be used to convert hero and ability IDs and other information provided by the API from the [dotaconstants](https://github.com/odota/dotaconstants) repository.\n    \n    The OpenDota API offers 50,000 free calls per month and a rate limit of 60 requests/minute. We also offer a Premium Tier with unlimited API calls and higher rate limits. Check out the [API page](https://www.opendota.com/api-keys) to learn more.\n    ",
-    "version": "21.0.0"
+    "version": "21.0.1"
   },
   "servers": [
     {
@@ -3145,6 +3145,33 @@
           "type": "integer"
         }
       },
+      "lessThanMatchIdParam": {
+        "name": "less_than_match_id",
+        "in": "query",
+        "description": "Get matches with a match ID lower than this value",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "minMmrParam": {
+        "name": "min_mmr",
+        "in": "query",
+        "description": "Minimum MMR for the matches",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "maxMmrParam": {
+        "name": "max_mmr",
+        "in": "query",
+        "description": "Maximum MMR for the matches",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
       "mmrAscendingParam": {
         "name": "mmr_ascending",
         "in": "query",
@@ -3158,15 +3185,6 @@
         "name": "mmr_descending",
         "in": "query",
         "description": "Order by MMR descending",
-        "required": false,
-        "schema": {
-          "type": "integer"
-        }
-      },
-      "lessThanMatchIdParam": {
-        "name": "less_than_match_id",
-        "in": "query",
-        "description": "Get matches with a match ID lower than this value",
         "required": false,
         "schema": {
           "type": "integer"
@@ -4439,13 +4457,19 @@
         "tags": ["public matches"],
         "parameters": [
           {
+            "$ref": "#/components/parameters/lessThanMatchIdParam"
+          },
+          {
+            "$ref": "#/components/parameters/minMmrParam"
+          },
+          {
+            "$ref": "#/components/parameters/maxMmrParam"
+          },
+          {
             "$ref": "#/components/parameters/mmrAscendingParam"
           },
           {
             "$ref": "#/components/parameters/mmrDescendingParam"
-          },
-          {
-            "$ref": "#/components/parameters/lessThanMatchIdParam"
           }
         ],
         "responses": {

--- a/spec.json
+++ b/spec.json
@@ -3154,19 +3154,19 @@
           "type": "integer"
         }
       },
-      "minMmrParam": {
-        "name": "min_mmr",
+      "minRankParam": {
+        "name": "min_rank",
         "in": "query",
-        "description": "Minimum MMR for the matches",
+        "description": "Minimum rank for the matches. Ranks are represented by integers (10-15: Herald, 20-25: Guardian, 30-35: Crusader, 40-45: Archon, 50-55: Legend, 60-65: Ancient, 70-75: Divine, 80-85: Immortal). Each increment represents an additional star.",
         "required": false,
         "schema": {
           "type": "integer"
         }
       },
-      "maxMmrParam": {
-        "name": "max_mmr",
+      "maxRankParam": {
+        "name": "max_rank",
         "in": "query",
-        "description": "Maximum MMR for the matches",
+        "description": "Maximum rank for the matches. Ranks are represented by integers (10-15: Herald, 20-25: Guardian, 30-35: Crusader, 40-45: Archon, 50-55: Legend, 60-65: Ancient, 70-75: Divine, 80-85: Immortal). Each increment represents an additional star.",
         "required": false,
         "schema": {
           "type": "integer"
@@ -4460,10 +4460,10 @@
             "$ref": "#/components/parameters/lessThanMatchIdParam"
           },
           {
-            "$ref": "#/components/parameters/minMmrParam"
+            "$ref": "#/components/parameters/minRankParam"
           },
           {
-            "$ref": "#/components/parameters/maxMmrParam"
+            "$ref": "#/components/parameters/maxRankParam"
           },
           {
             "$ref": "#/components/parameters/mmrAscendingParam"


### PR DESCRIPTION
Adds `minRank` and `maxRank` query parameters and uses `avg_rank_tier` field in public_matches to filter results.

```js
    "/publicMatches": {
      get: {
...
        parameters: [
          { $ref: "#/components/parameters/lessThanMatchIdParam" },
          { $ref: "#/components/parameters/minRankParam" },
          { $ref: "#/components/parameters/maxRankParam" },
          { $ref: "#/components/parameters/mmrAscendingParam" },
          { $ref: "#/components/parameters/mmrDescendingParam" },
        ],
...
        route: () => "/publicMatches",
        func: async (req, res, cb) => {
...
          if (req.query.mmr_ascending) {
            order = "ORDER BY avg_rank_tier ASC NULLS LAST";
          } else if (req.query.mmr_descending) {
            order = "ORDER BY avg_rank_tier DESC NULLS LAST";
          } else {
            order = "ORDER BY match_id DESC";
            moreThan = 0;
          }
          let minRank= req.query.min_rank
            ? `AND avg_rank_tier >= ${req.query.min_rank}`
            : "";
          let maxRank= req.query.max_rank
            ? `AND avg_rank_tier <= ${req.query.max_rank}`
            : "";

          db.raw(
            `
          WITH match_ids AS (SELECT match_id FROM public_matches
          WHERE TRUE
          AND match_id > ?
          AND match_id < ?
          ${minRank}
          ${maxRank}
          ${order}
          LIMIT 100)
          SELECT * FROM
...
```