### PR TITLE
Hide data for players with match history disabled

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -32,6 +32,7 @@ type QueryObj = {
   having?: number;
   // Number of results to fetch from the database (before filter/sort)
   dbLimit?: number;
+  isPrivate?: boolean;
 };
 
 type StringDict = { [key: string]: string };

--- a/routes/api.ts
+++ b/routes/api.ts
@@ -4,6 +4,7 @@ import spec from './spec';
 import { readCache } from '../store/cacheFunctions';
 import { redisCount } from '../util/utility';
 import redis from '../store/redis';
+import db from '../store/db';
 
 //@ts-ignore
 const api: Router = new Router();
@@ -32,7 +33,7 @@ api.use('/players/:account_id/:info?', async (req, res, cb) => {
   }
 });
 // Player endpoints middleware
-api.use('/players/:account_id/:info?', (req, res, cb) => {
+api.use('/players/:account_id/:info?', async (req, res, cb) => {
   if (!Number.isInteger(Number(req.params.account_id))) {
     return res.status(400).json({ error: 'invalid account id' });
   }
@@ -55,6 +56,9 @@ api.use('/players/:account_id/:info?', (req, res, cb) => {
     filterCols = filterCols.concat(filterDeps[key as FilterType] || []);
   });
   const sortArr = (req.query.sort || []) as (keyof ParsedPlayerMatch)[];
+  const privacy = await db.raw('SELECT fh_unavailable FROM players WHERE account_id = ?', [req.params.account_id]);
+  // User can view their own stats
+  const isPrivate = Boolean(privacy.rows[0]?.fh_unavailable) && req.user?.account_id !== req.params.account_id;
   (req as unknown as Express.ExtRequest).queryObj = {
     project: [
       'match_id',
@@ -68,6 +72,7 @@ api.use('/players/:account_id/:info?', (req, res, cb) => {
     limit: Number(req.query.limit),
     offset: Number(req.query.offset),
     having: Number(req.query.having),
+    isPrivate,
   };
   return cb();
 });

--- a/routes/api.ts
+++ b/routes/api.ts
@@ -34,47 +34,51 @@ api.use('/players/:account_id/:info?', async (req, res, cb) => {
 });
 // Player endpoints middleware
 api.use('/players/:account_id/:info?', async (req, res, cb) => {
-  if (!Number.isInteger(Number(req.params.account_id))) {
-    return res.status(400).json({ error: 'invalid account id' });
+  try {
+    if (!Number.isInteger(Number(req.params.account_id))) {
+      return res.status(400).json({ error: 'invalid account id' });
+    }
+    (req as unknown as Express.ExtRequest).originalQuery = JSON.parse(
+      JSON.stringify(req.query),
+    );
+    // Enable significance filter by default, disable it if 0 is passed
+    if (req.query.significant === '0') {
+      delete req.query.significant;
+    } else {
+      req.query.significant = '1';
+    }
+    let filterCols: (keyof ParsedPlayerMatch)[] = [];
+    Object.keys(req.query).forEach((key) => {
+      // numberify and arrayify everything in query
+      req.query[key] = []
+        .concat(req.query[key] as [])
+        .map((e) => (Number.isNaN(Number(e)) ? e : Number(e))) as any;
+      // build array of required projections due to filters
+      filterCols = filterCols.concat(filterDeps[key as FilterType] || []);
+    });
+    const sortArr = (req.query.sort || []) as (keyof ParsedPlayerMatch)[];
+    const privacy = await db.raw('SELECT fh_unavailable FROM players WHERE account_id = ?', [req.params.account_id]);
+    // User can view their own stats
+    const isPrivate = Boolean(privacy.rows[0]?.fh_unavailable) && req.user?.account_id !== req.params.account_id;
+    (req as unknown as Express.ExtRequest).queryObj = {
+      project: [
+        'match_id',
+        'player_slot',
+        'radiant_win',
+        ...filterCols,
+        ...sortArr,
+      ],
+      filter: (req.query || {}) as unknown as ArrayifiedFilters,
+      sort: sortArr[0],
+      limit: Number(req.query.limit),
+      offset: Number(req.query.offset),
+      having: Number(req.query.having),
+      isPrivate,
+    };
+    return cb();
+  } catch (e) {
+    return cb(e);
   }
-  (req as unknown as Express.ExtRequest).originalQuery = JSON.parse(
-    JSON.stringify(req.query),
-  );
-  // Enable significance filter by default, disable it if 0 is passed
-  if (req.query.significant === '0') {
-    delete req.query.significant;
-  } else {
-    req.query.significant = '1';
-  }
-  let filterCols: (keyof ParsedPlayerMatch)[] = [];
-  Object.keys(req.query).forEach((key) => {
-    // numberify and arrayify everything in query
-    req.query[key] = []
-      .concat(req.query[key] as [])
-      .map((e) => (Number.isNaN(Number(e)) ? e : Number(e))) as any;
-    // build array of required projections due to filters
-    filterCols = filterCols.concat(filterDeps[key as FilterType] || []);
-  });
-  const sortArr = (req.query.sort || []) as (keyof ParsedPlayerMatch)[];
-  const privacy = await db.raw('SELECT fh_unavailable FROM players WHERE account_id = ?', [req.params.account_id]);
-  // User can view their own stats
-  const isPrivate = Boolean(privacy.rows[0]?.fh_unavailable) && req.user?.account_id !== req.params.account_id;
-  (req as unknown as Express.ExtRequest).queryObj = {
-    project: [
-      'match_id',
-      'player_slot',
-      'radiant_win',
-      ...filterCols,
-      ...sortArr,
-    ],
-    filter: (req.query || {}) as unknown as ArrayifiedFilters,
-    sort: sortArr[0],
-    limit: Number(req.query.limit),
-    offset: Number(req.query.offset),
-    having: Number(req.query.having),
-    isPrivate,
-  };
-  return cb();
 });
 api.use('/teams/:team_id/:info?', (req, res, cb) => {
   if (!Number.isInteger(Number(req.params.team_id))) {

--- a/store/queries.ts
+++ b/store/queries.ts
@@ -222,6 +222,10 @@ export async function getPlayerMatchesWithMetadata(
   if (!accountId || !Number.isInteger(accountId) || accountId <= 0) {
     return [[], null];
   }
+  if (queryObj.isPrivate) {
+    // User disabled public match history from Dota, so don't return matches
+    return [[], null];
+  }
   redisCount(redis, 'player_matches');
   // call clean method to ensure we have column info cached
   await cleanRowCassandra(cassandra, 'player_caches', {});

--- a/test/test.ts
+++ b/test/test.ts
@@ -123,6 +123,23 @@ describe(c.blue('[TEST] player_caches'), async () => {
     assert.equal(data.length, 1);
   });
 });
+describe(c.blue('[TEST] privacy setting'), async () => {
+  it('should return one row due to default privacy setting', async () => {
+    await db.raw('UPDATE players SET fh_unavailable = NULL WHERE account_id = ?', ['120269134']);
+    const res = await supertest(app).get('/api/players/120269134/matches');
+    assert.equal(res.body.length, 1);
+  });
+  it('should return one row due to visible match data', async () => {
+    await db.raw('UPDATE players SET fh_unavailable = FALSE WHERE account_id = ?', ['120269134']);
+    const res = await supertest(app).get('/api/players/120269134/matches');
+    assert.equal(res.body.length, 1);
+  });
+  it('should return no rows due to hidden match data', async () => {
+    await db.raw('UPDATE players SET fh_unavailable = TRUE WHERE account_id = ?', ['120269134']);
+    const res = await supertest(app).get('/api/players/120269134/matches');
+    assert.equal(res.body.length, 0);
+  });
+});
 describe(c.blue('[TEST] players'), async () => {
   let data: any = null;
   before(async () => {


### PR DESCRIPTION
fixes #2645 

Return an empty array for player endpoints if the player has unchecked Expose Public Match Data and we've picked up the change via profile refresh.

If the player is logged in and matches the account_id of the player being requested, return data normally.