### PR TITLE
Neutral items history

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -153,6 +153,7 @@ interface ParsedPlayer extends Player {
   sen: any;
   lane_role: number | null;
   neutral_tokens_log: any[];
+  neutral_item_history: NeutralItemHistory[];
 
   party_size?: number;
 
@@ -196,6 +197,12 @@ interface ParsedPlayer extends Player {
 
   // Added temporarily
   rank_tier?: number;
+}
+
+interface NeutralItemHistory {
+  time: number;
+  item_neutral: string;
+  item_neutral_enhancement: string;
 }
 
 // Data to pass to insertMatch from GC

--- a/routes/responses/MatchResponse.ts
+++ b/routes/responses/MatchResponse.ts
@@ -934,21 +934,21 @@ export default {
               },
             },
             neutral_item_history: {
-              description: 'Object containing on neutral item history',
+              description: 'Object containing information on neutral item history',
               type: 'array',
               items: {
                 type: 'object',
                 properties: {
                   time: {
-                    description: 'Time in seconds at which the item was neutralized',
+                    description: 'Time in seconds at which the item was crafted',
                     type: 'integer'
                   },
                   item_neutral: {
-                    description: 'Neutral item',
+                    description: 'Neutral item name',
                     type: 'string'
                   },
                   item_neutral_enhancement: {
-                    description: 'Neutral item enhancement',
+                    description: 'Neutral enhancement name',
                     type: 'string'
                   }
                 }

--- a/routes/responses/MatchResponse.ts
+++ b/routes/responses/MatchResponse.ts
@@ -933,6 +933,27 @@ export default {
                 },
               },
             },
+            neutral_item_history: {
+              description: 'Object containing on neutral item history',
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  time: {
+                    description: 'Time in seconds at which the item was neutralized',
+                    type: 'integer'
+                  },
+                  item_neutral: {
+                    description: 'Neutral item',
+                    type: 'string'
+                  },
+                  item_neutral_enhancement: {
+                    description: 'Neutral item enhancement',
+                    type: 'string'
+                  }
+                }
+              }
+            }
           },
         },
       },

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -138,7 +138,8 @@ CREATE TABLE IF NOT EXISTS player_matches (
   observers_placed int,
   party_size int,
   net_worth int,
-  neutral_tokens_log json[]
+  neutral_tokens_log json[],
+  neutral_item_history json[]
 );
 CREATE INDEX IF NOT EXISTS player_matches_account_id_idx on player_matches(account_id) WHERE account_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS player_matches_hero_id_idx on player_matches(hero_id);


### PR DESCRIPTION
Adds ability to track all neutral items player had in match and their enhancements
Related to this PR odota/parser#75