### PR TITLE
:recycle: Refactor timestamp handling to use UTC

### DIFF
--- a/dev/copyUsage.ts
+++ b/dev/copyUsage.ts
@@ -2,8 +2,8 @@ import db from '../store/db';
 import moment from 'moment';
 
 async function start() {
-  const startTime = moment().startOf('month').format('YYYY-MM-DD');
-  const endTime = moment().endOf('month').format('YYYY-MM-DD');
+  const startTime = moment.utc().startOf('month').format('YYYY-MM-DD');
+  const endTime = moment.utc().endOf('month').format('YYYY-MM-DD');
   const { rows } = await db.raw(
     `
         SELECT
@@ -21,7 +21,7 @@ async function start() {
     [startTime, endTime],
   );
   // console.log(rows);
-  const apiTimestamp = moment().startOf('month');
+  const apiTimestamp = moment.utc().startOf('month');
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
     const curr = await db.raw(

--- a/fetcher/getGcData.ts
+++ b/fetcher/getGcData.ts
@@ -52,12 +52,12 @@ async function saveGcData(
   redis.hincrby('retrieverSteamIDs', steamid, 1);
   redis.expireat(
     'retrieverSteamIDs',
-    moment().startOf('day').add(1, 'day').format('X'),
+    moment.utc().startOf('day').add(1, 'day').format('X'),
   );
   redis.hincrby('retrieverIPs', ip, 1);
   redis.expireat(
     'retrieverIPs',
-    moment().startOf('day').add(1, 'day').format('X'),
+    moment.utc().startOf('day').add(1, 'day').format('X'),
   );
   if (headers['x-match-noretry']) {
     // Steam is blocking this match for community prediction, so return error to prevent retry
@@ -78,12 +78,12 @@ async function saveGcData(
   redis.hincrby('retrieverSuccessSteamIDs', steamid, 1);
   redis.expireat(
     'retrieverSuccessSteamIDs',
-    moment().startOf('day').add(1, 'day').format('X'),
+    moment.utc().startOf('day').add(1, 'day').format('X'),
   );
   redis.hincrby('retrieverSuccessIPs', ip, 1);
   redis.expireat(
     'retrieverSuccessIPs',
-    moment().startOf('day').add(1, 'day').format('X'),
+    moment.utc().startOf('day').add(1, 'day').format('X'),
   );
   const players = data.match.players.map(
     (p: any, i: number): GcPlayer => ({

--- a/routes/api.ts
+++ b/routes/api.ts
@@ -67,7 +67,7 @@ api.use('/players/:account_id/:info?', async (req, res, next) => {
       isPrivate,
     };
     // Keep track of recently visited account IDs for caching
-    await redis.zadd('visitedIds', moment().format('X'), req.params.account_id);
+    await redis.zadd('visitedIds', moment.utc().format('X'), req.params.account_id);
     await redis.zremrangebyrank('visitedIds', '0', '-50001');
     return next();
   } catch (e) {

--- a/routes/keyManagement.ts
+++ b/routes/keyManagement.ts
@@ -122,8 +122,8 @@ keys
               ORDER BY month DESC
             `,
           [
-            moment().subtract(5, 'month').startOf('month'),
-            moment().endOf('month'),
+            moment.utc().subtract(5, 'month').startOf('month'),
+            moment.utc().endOf('month'),
             req.user?.account_id,
           ],
         );
@@ -237,7 +237,7 @@ keys
       const sub = await stripe.subscriptions.create({
         customer: customer_id,
         items: [{ plan: stripeAPIPlan }],
-        billing_cycle_anchor: moment().add(1, 'month').startOf('month').unix(),
+        billing_cycle_anchor: moment.utc().add(1, 'month').startOf('month').unix(),
         metadata: {
           apiKey,
         },

--- a/routes/spec.ts
+++ b/routes/spec.ts
@@ -1708,7 +1708,7 @@ Without a key, you can make 2,000 free calls per day at a rate limit of 60 reque
                   keyArr.push(
                     // Redis keys are in the format `${heroId}:${tier}:${name}:${timestamp}`
                     // Get the unix timestamps for the start of the last 7 days
-                    `${heroId}:${tier}:${name}:${moment()
+                    `${heroId}:${tier}:${name}:${moment.utc()
                       .startOf('day')
                       .subtract(i, 'day')
                       .format('X')}`,
@@ -1820,7 +1820,7 @@ Without a key, you can make 2,000 free calls per day at a rate limit of 60 reque
             AND matches.start_time > ?
             GROUP BY pm2.hero_id
             ORDER BY games_played DESC`,
-            [heroId, moment().subtract(1, 'year').format('X')],
+            [heroId, moment.utc().subtract(1, 'year').format('X')],
           );
           return res.json(rows);
         },

--- a/store/queue.ts
+++ b/store/queue.ts
@@ -77,7 +77,7 @@ export async function runReliableQueue(
       )
       RETURNING *
       `,
-        [moment().add(3, 'minute'), queueName],
+        [moment.utc().add(3, 'minute'), queueName],
       );
       const job = result && result.rows && result.rows[0];
       if (job) {

--- a/svc/buildsets.ts
+++ b/svc/buildsets.ts
@@ -26,7 +26,7 @@ async function doBuildSets() {
   // Refresh tracked players with expire date in the future
   await Promise.all(
     tracked.map((id) =>
-      command.zadd('tracked', moment().add(1, 'day').format('X'), id),
+      command.zadd('tracked', moment.utc().add(1, 'day').format('X'), id),
     ),
   );
   await command.exec();

--- a/svc/counts.ts
+++ b/svc/counts.ts
@@ -100,7 +100,7 @@ async function updateRecord(
   );
   // Keep only 100 top scores
   redis.zremrangebyrank(`records:${field}`, '0', '-101');
-  const expire = moment().add(1, 'month').startOf('month').format('X');
+  const expire = moment.utc().add(1, 'month').startOf('month').format('X');
   redis.expireat(`records:${field}`, expire);
 }
 async function updateRecords(match: Match) {
@@ -215,8 +215,8 @@ async function updateHeroCounts(match: Match) {
   if (!tier) {
     return;
   }
-  const timestamp = moment().startOf('day').unix();
-  const expire = moment().startOf('day').add(8, 'day').unix();
+  const timestamp = moment.utc().startOf('day').unix();
+  const expire = moment.utc().startOf('day').add(8, 'day').unix();
   for (let i = 0; i < match.players.length; i += 1) {
     const player = match.players[i];
     const heroId = player.hero_id;

--- a/svc/parser.ts
+++ b/svc/parser.ts
@@ -156,7 +156,7 @@ async function parseProcessor(job: ParseJob, metadata: JobMetadata) {
     const message = c[colors[type]](
       `[${new Date().toISOString()}] [parser] [${type}: ${
         end - start
-      }ms] [api: ${apiTime}ms] [gcdata: ${gcTime}ms] [parse: ${parseTime}ms] [queued: ${moment(
+      }ms] [api: ${apiTime}ms] [gcdata: ${gcTime}ms] [parse: ${parseTime}ms] [queued: ${moment.utc(
         metadata.timestamp,
       ).fromNow()}] [pri: ${metadata.priority}] [att: ${metadata.attempts}] ${
         job.match_id

--- a/svc/web.ts
+++ b/svc/web.ts
@@ -94,7 +94,7 @@ const onResFinish = async (
   ) {
     if (res.locals.isAPIRequest) {
       const apiKey = res.locals.usageIdentifier;
-      const apiTimestamp = moment().startOf('month');
+      const apiTimestamp = moment.utc().startOf('month');
       const rows = await db.from('api_keys').where({
         api_key: apiKey,
       });
@@ -126,15 +126,15 @@ const onResFinish = async (
   await redis.zincrby('api_paths', 1, req.method + ' ' + normPath);
   await redis.expireat(
     'api_paths',
-    moment().startOf('hour').add(1, 'hour').format('X'),
+    moment.utc().startOf('hour').add(1, 'hour').format('X'),
   );
   await redis.zincrby('api_status', 1, res.statusCode);
   await redis.expireat(
     'api_status',
-    moment().startOf('hour').add(1, 'hour').format('X'),
+    moment.utc().startOf('hour').add(1, 'hour').format('X'),
   );
   if (req.user && req.user.account_id) {
-    await redis.zadd('visitors', moment().format('X'), req.user.account_id);
+    await redis.zadd('visitors', moment.utc().format('X'), req.user.account_id);
     await redis.zremrangebyrank('visitors', '0', '-50001');
   }
   await redis.lpush('load_times', elapsed);
@@ -443,8 +443,8 @@ app.get('/admin/retrieverMetrics', async (req, res, next) => {
 });
 app.get('/admin/apiMetrics', async (req, res, next) => {
   try {
-    const startTime = moment().startOf('month').format('YYYY-MM-DD');
-    const endTime = moment().endOf('month').format('YYYY-MM-DD');
+    const startTime = moment.utc().startOf('month').format('YYYY-MM-DD');
+    const endTime = moment.utc().endOf('month').format('YYYY-MM-DD');
     const [topUsersKey, numUsersKey] = await Promise.all([
       db.raw(
         `

--- a/util/buildStatus.ts
+++ b/util/buildStatus.ts
@@ -24,7 +24,7 @@ async function countDay(prefix: MetricName) {
   const keyArr = [];
   for (let i = 0; i < 24; i += 1) {
     keyArr.push(
-      `${prefix}:v2:${moment()
+      `${prefix}:v2:${moment.utc()
         .startOf('hour')
         .subtract(i, 'hour')
         .format('X')}`,
@@ -36,7 +36,7 @@ async function countDay(prefix: MetricName) {
 
 async function countHour(prefix: MetricName) {
   const result = await redis.get(
-    `${prefix}:v2:${moment().startOf('hour').format('X')}`,
+    `${prefix}:v2:${moment.utc().startOf('hour').format('X')}`,
   );
   return Number(result);
 }
@@ -44,7 +44,7 @@ async function countHour(prefix: MetricName) {
 async function countLastHour(prefix: MetricName) {
   // Get counts for previous full hour (not current)
   const result = await redis.get(
-    `${prefix}:v2:${moment().startOf('hour').subtract(1, 'hour').format('X')}`,
+    `${prefix}:v2:${moment.utc().startOf('hour').subtract(1, 'hour').format('X')}`,
   );
   return Number(result);
 }
@@ -54,7 +54,7 @@ async function countDayDistinct(prefix: MetricName) {
   const keyArr = [];
   for (let i = 0; i < 24; i += 1) {
     keyArr.push(
-      `${prefix}:v2:${moment()
+      `${prefix}:v2:${moment.utc()
         .startOf('hour')
         .subtract(i, 'hour')
         .format('X')}`,
@@ -150,7 +150,7 @@ export async function buildStatus() {
         // user_players_recent: async () =>
         //   redis.zcount(
         //     'visitors',
-        //     moment().subtract(30, 'day').format('X'),
+        //     moment.utc().subtract(30, 'day').format('X'),
         //     '+inf',
         //   ),
         // distinct_match_players_last_day: async () =>

--- a/util/insert.ts
+++ b/util/insert.ts
@@ -399,7 +399,7 @@ export async function insertMatch(
       //     'distinct_match_player_user',
       //     p.account_id.toString(),
       //   );
-      //   if (visitTime > Number(moment().subtract(30, 'day').format('X'))) {
+      //   if (visitTime > Number(moment.utc().subtract(30, 'day').format('X'))) {
       //     redisCountDistinct(
       //       'distinct_match_player_recent_user',
       //       p.account_id.toString(),

--- a/util/utility.ts
+++ b/util/utility.ts
@@ -340,10 +340,10 @@ export function getStartOfBlockMinutes(size: number, offset: number) {
   return (blockStart + offset * blockS).toFixed(0);
 }
 export function getEndOfMonth() {
-  return moment().endOf('month').unix();
+  return moment.utc().endOf('month').unix();
 }
 export function getEndOfDay() {
-  return moment().endOf('day').unix();
+  return moment.utc().endOf('day').unix();
 }
 /**
  * Finds the arithmetic mean of the input array
@@ -785,18 +785,18 @@ export async function redisCount(prefix: MetricName, incrBy = 1) {
   if (!redis) {
     return;
   }
-  const key = `${prefix}:v2:${moment().startOf('hour').format('X')}`;
+  const key = `${prefix}:v2:${moment.utc().startOf('hour').format('X')}`;
   await redis.incrby(key, incrBy);
-  await redis.expireat(key, moment().startOf('hour').add(1, 'day').format('X'));
+  await redis.expireat(key, moment.utc().startOf('hour').add(1, 'day').format('X'));
 }
 
 export async function redisCountDistinct(prefix: MetricName, value: string) {
   if (!redis) {
     return;
   }
-  const key = `${prefix}:v2:${moment().startOf('hour').format('X')}`;
+  const key = `${prefix}:v2:${moment.utc().startOf('hour').format('X')}`;
   await redis.pfadd(key, value);
-  await redis.expireat(key, moment().startOf('hour').add(1, 'day').format('X'));
+  await redis.expireat(key, moment.utc().startOf('hour').add(1, 'day').format('X'));
 }
 
 /**


### PR DESCRIPTION
Following up from this discord chat: https://discord.com/channels/144629812982448128/144629812982448128/1349940912205070380

Timestamp processing should use UTC, and `moment()` uses local time be default. So this PR just replaces all usages of `moment()` with `moment.utc()`