### PR TITLE
Fix averageMedal calculation

### DIFF
--- a/util/utility.ts
+++ b/util/utility.ts
@@ -356,10 +356,10 @@ export function average(data: number[]) {
  * */
 export function averageMedal(values: number[]) {
   const numStars = values.map(
-    (value) => Number(String(value)[0]) * 5 + (value % 10),
+    (value) => Number(String(value)[0]) * 5 + (value % 10) - 1,
   );
-  const avgStars = numStars.reduce((a, b) => a + b, 0) / numStars.length;
-  return Math.floor(avgStars / 5) * 10 + Math.max(1, Math.round(avgStars % 5));
+  const avgStars = Math.round(numStars.reduce((a, b) => a + b, 0) / numStars.length);
+  return Math.floor(avgStars / 5) * 10 + avgStars % 5 + 1;
 }
 /**
  * Finds the standard deviation of the input array


### PR DESCRIPTION
The `averageMedal` method used for computing the average of a set of ranks is very slightly incorrect. We basically treat the ranks as if they are base 5 numbers, and average them based on that. The issue is that rank  are only *almost* base 5 numbers. the second digit is 1-5, when in a base 5 number it would be 0-4. This PR updates the method to account for that so that they get averaged properly.

Here is an example of a scenario where the current implementation is incorrect: 
```js
var ranks = [ 14, 15, 21 ]; // Herald 4, Herald 5, Guardian 1

// EXPECTED AVERAGE: 15 (Herald 5)

// before this PR
console.log(averageMedal(ranks)) // PRINTS: 21 (Guardian 1)

// after this PR
console.log(averageMedal(ranks)) // PRINTS: 15 (Herald 5)
```
