### PR TITLE
Added documentation for pauses field in MatchResponse

### DIFF
--- a/svc/api/responses/MatchResponse.ts
+++ b/svc/api/responses/MatchResponse.ts
@@ -1001,6 +1001,24 @@ export default {
         description: 'replay_url',
         type: 'string',
       },
+      pauses: {
+        description:
+          'Array containing information about pauses during the game. Each item contains the time and duration of the pause.',
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            time: {
+              description: 'Time in seconds at which pause started',
+              type: 'integer',
+            },
+            duration: {
+              description: 'The duration of the pause',
+              type: 'integer',
+            },
+          },
+        },
+      }
     },
   },
 };


### PR DESCRIPTION
## Summary
Added documentation for the `pauses` field in the MatchResponse schema.

## Changes
- Added documentation for the `pauses` array field describing pause information during matches
- Documented `time` property as when the pause started (in seconds)
- Documented `duration` property as the length of the pause

## Sample Data
```json
"pauses":[{"time":46011,"duration":512},{"time":49119,"duration":376},{"time":65549,"duration":242}]
```

This provides all match times when pauses occurred and their duration.