### PR TITLE
Make inserter batch size and parallelism configurable

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -40,6 +40,8 @@ const defaults = {
   PARSER_PARALLELISM: "1", // Number of simultaneous parse jobs to process
   FULLHISTORY_PARALLELISM: "1", // Number of simultaneous fullhistory (player refresh) jobs to process
   GCDATA_PARALLELISM: "1", // Number of simultaneous GC match details jobs to process
+  INSERTER_BATCH_SIZE: "100", // Max insert_queue rows pulled per inserter loop tick
+  INSERTER_PARALLELISM: "100", // Max concurrent insertMatch per tick
   BENCHMARK_RETENTION_MINUTES: "60", // minutes in block to retain benchmark data for percentile
   GCDATA_PERCENT: "0", // percent of inserted matches to randomly queue for GC data
   RATING_PERCENT: "0", // percent of ranked matches to update player ratings with

--- a/svc/inserter.ts
+++ b/svc/inserter.ts
@@ -1,8 +1,12 @@
+import config from "../config.ts";
 import db from "./store/db.ts";
 import redis, { redisCount } from "./store/redis.ts";
 import { insertMatch } from "./util/insert.ts";
 import { cacheTrackedPlayers } from "./util/queries.ts";
 import { runInLoop } from "./store/queue.ts";
+
+const batchSize = Math.max(1, Number(config.INSERTER_BATCH_SIZE) || 100);
+const parallelism = Math.max(1, Number(config.INSERTER_PARALLELISM) || 100);
 
 // Make sure we have tracked players loaded
 const trackedExists = await redis.exists("tracked");
@@ -12,7 +16,8 @@ if (!trackedExists) {
 
 await runInLoop(async function insert() {
   const { rows } = await db.raw(
-    "SELECT match_seq_num, data FROM insert_queue WHERE processed = FALSE ORDER BY match_seq_num ASC LIMIT 100",
+    "SELECT match_seq_num, data FROM insert_queue WHERE processed = FALSE ORDER BY match_seq_num ASC LIMIT ?",
+    [batchSize],
   );
   if (!rows.length) {
     await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -29,19 +34,30 @@ await runInLoop(async function insert() {
     redisCount("inserter_timeout");
     process.exit(1);
   }, 10000);
-  await Promise.allSettled(
-    rows.map(async (r: any) => {
-      const match = r.data;
-      if (!match) {
-        throw new Error("no match in row: %s", r.match_seq_num);
+  try {
+    for (let offset = 0; offset < rows.length; offset += parallelism) {
+      const chunk = rows.slice(offset, offset + parallelism);
+      const settled = await Promise.allSettled(
+        chunk.map(async (r: { match_seq_num: number; data: unknown }) => {
+          const match = r.data;
+          if (!match) {
+            throw new Error(`no match in row: ${r.match_seq_num}`);
+          }
+          await insertMatch(match as InsertMatchInput, {
+            type: "api",
+            origin: "scanner",
+            skipRating,
+            insertSeqNum: r.match_seq_num,
+          });
+        }),
+      );
+      for (const s of settled) {
+        if (s.status === "rejected") {
+          console.log(s.reason);
+        }
       }
-      await insertMatch(match, {
-        type: "api",
-        origin: "scanner",
-        skipRating,
-        insertSeqNum: r.match_seq_num,
-      });
-    }),
-  );
-  clearTimeout(timeout);
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
 }, 0);


### PR DESCRIPTION
### What
- Adds **`INSERTER_BATCH_SIZE`** and **`INSERTER_PARALLELISM`** (defaults **100** / **100**) so operators can tune how many `insert_queue` rows are pulled per tick and how many **`insertMatch`** calls run at once, without code changes.
- Replaces the hardcoded **`LIMIT 100`** with a bound **`LIMIT ?`** driven by batch size.
- Processes each tick in **waves** of at most `INSERTER_PARALLELISM` inserts (with defaults, that is still one wave of up to 100, matching previous behavior).
- Keeps the maintainer’s **10s watchdog** that records **`inserter_timeout`** and **`process.exit(1)`** if a tick stalls; wraps the tick in **`try` / `finally`** so the timer is always cleared on success.
- Fixes the invalid **`Error("no match in row: %s", …)`** usage and logs **`Promise.allSettled`** rejections per chunk.

### Why
The pain was **too many concurrent inserts** when the system is under load; **parallelism** is what sets that peak, **batch size** is how many rows you dequeue per tick. Exposing both as config makes it easy to **lower** concurrency when Postgres is saturated while **defaults stay at the old 100-wide rate** so ingest keeps up when healthy.
