### PR TITLE
Tag connections with application_name

### DIFF
--- a/svc/api/spec.ts
+++ b/svc/api/spec.ts
@@ -93,6 +93,7 @@ import { matchupToString } from "../util/matchups.ts";
 
 const pool = new Pool({
   connectionString: config.READONLY_POSTGRES_URL,
+  application_name: `odota-${config.APP_NAME || "unknown"}-explorer`,
   statement_timeout: 15000,
   query_timeout: 15000,
   lock_timeout: 15000,

--- a/svc/store/db.ts
+++ b/svc/store/db.ts
@@ -14,7 +14,10 @@ console.log(
 
 export const db = knex({
   client: "pg",
-  connection: config.POSTGRES_URL,
+  connection: {
+    connectionString: config.POSTGRES_URL,
+    application_name: `odota-${config.APP_NAME || "unknown"}`,
+  },
   pool: {
     min: 0,
     max: Number(config.POSTGRES_MAX_CONNECTIONS),

--- a/svc/store/queue.ts
+++ b/svc/store/queue.ts
@@ -55,7 +55,10 @@ export async function runReliableQueue(
   getCapacity?: () => Promise<number>,
 ) {
   const executor = async (i: number) => {
-    const consumer = new Client(config.POSTGRES_URL);
+    const consumer = new Client({
+      connectionString: config.POSTGRES_URL,
+      application_name: `odota-${config.APP_NAME || "unknown"}-queue`,
+    });
     await consumer.connect();
     while (true) {
       // If we have a way to measure capacity, throttle the processing speed based on capacity

--- a/svc/util/archiveUtil.ts
+++ b/svc/util/archiveUtil.ts
@@ -43,7 +43,10 @@ export async function archivePostgresStream() {
     ORDER BY match_id asc`,
     [],
   );
-  const pg = new Client(config.POSTGRES_URL);
+  const pg = new Client({
+    connectionString: config.POSTGRES_URL,
+    application_name: `odota-${config.APP_NAME || "unknown"}-archive`,
+  });
   await pg.connect();
   const stream = pg.query(query);
   let i = 0;


### PR DESCRIPTION
Set application_name on every Postgres connection so each session is
identifiable in pg_stat_activity. No behaviour change.

Naming:
- Shared Knex pool: odota-<APP_NAME>
- runReliableQueue dedicated Client: odota-<APP_NAME>-queue
- Explorer readonly Pool: odota-<APP_NAME>-explorer
- archivePostgresStream Client: odota-<APP_NAME>-archive

APP_NAME is set per process by ecosystem.config.js (e.g. inserter,
scanner, web, parser); falls back to "unknown" when run outside PM2.

With ~30 backend roles plus a clustered web role, this makes it possible
to answer "which service is holding connections?" with a single query:
```sql
SELECT application_name, state, count(*)
FROM pg_stat_activity
GROUP BY 1, 2 ORDER BY 3 DESC;
```