### PR TITLE
Exponential backoff in runInLoop on failure

### DIFF
--- a/svc/store/queue.ts
+++ b/svc/store/queue.ts
@@ -127,9 +127,7 @@ export async function runReliableQueue(
  * not hammered by tight-loop restarts.
  *
  * After MAX_CONSECUTIVE_FAILURES in a row, exits the process so PM2 can do a
- * clean-slate restart (fresh Knex pool, cleared in-memory state). With the
- * default backoff curve this is ~7.5 minutes of sustained failure before
- * giving up, which is well past any transient DB blip.
+ * clean-slate restart (fresh Knex pool, cleared in-memory state).
  *
  * The lastRun health beacon is only refreshed on success, so the existing
  * HEALTH_TIMEOUT alerting still detects a stuck worker before exit.

--- a/svc/store/queue.ts
+++ b/svc/store/queue.ts
@@ -121,17 +121,26 @@ export async function runReliableQueue(
 
 /**
  * Runs an async function on a loop, waiting the delay between each iteration.
+ *
  * On failure, logs and sleeps with exponential backoff + jitter (capped at 30s)
  * before retrying, so a sick dependency (e.g. Postgres at max_connections) is
- * not hammered by tight-loop restarts. The lastRun health beacon is only
- * refreshed on success, so the existing HEALTH_TIMEOUT alerting still detects
- * a stuck worker.
+ * not hammered by tight-loop restarts.
+ *
+ * After MAX_CONSECUTIVE_FAILURES in a row, exits the process so PM2 can do a
+ * clean-slate restart (fresh Knex pool, cleared in-memory state). With the
+ * default backoff curve this is ~7.5 minutes of sustained failure before
+ * giving up, which is well past any transient DB blip.
+ *
+ * The lastRun health beacon is only refreshed on success, so the existing
+ * HEALTH_TIMEOUT alerting still detects a stuck worker before exit.
+ *
  * @param func
  * @param delay
  */
 export async function runInLoop(func: () => Promise<void>, delay: number) {
   const BASE_BACKOFF_MS = 250;
   const MAX_BACKOFF_MS = 30_000;
+  const MAX_CONSECUTIVE_FAILURES = 10;
   let consecutiveFailures = 0;
   while (true) {
     console.log("running %s", func.name);
@@ -146,6 +155,14 @@ export async function runInLoop(func: () => Promise<void>, delay: number) {
         consecutiveFailures,
         e,
       );
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        console.error(
+          "%s exceeded %d consecutive failures, exiting for PM2 restart",
+          func.name,
+          MAX_CONSECUTIVE_FAILURES,
+        );
+        process.exit(1);
+      }
       // 2 ** capped so the exponent doesn't overflow on long outages
       const exp = Math.min(consecutiveFailures, 10);
       const backoff = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * 2 ** exp);

--- a/svc/store/queue.ts
+++ b/svc/store/queue.ts
@@ -120,15 +120,40 @@ export async function runReliableQueue(
 }
 
 /**
- * Runs an async function on a loop, waiting the delay between each iteration
+ * Runs an async function on a loop, waiting the delay between each iteration.
+ * On failure, logs and sleeps with exponential backoff + jitter (capped at 30s)
+ * before retrying, so a sick dependency (e.g. Postgres at max_connections) is
+ * not hammered by tight-loop restarts. The lastRun health beacon is only
+ * refreshed on success, so the existing HEALTH_TIMEOUT alerting still detects
+ * a stuck worker.
  * @param func
  * @param delay
  */
 export async function runInLoop(func: () => Promise<void>, delay: number) {
+  const BASE_BACKOFF_MS = 250;
+  const MAX_BACKOFF_MS = 30_000;
+  let consecutiveFailures = 0;
   while (true) {
     console.log("running %s", func.name);
     const start = Date.now();
-    await func();
+    try {
+      await func();
+    } catch (e) {
+      consecutiveFailures += 1;
+      console.error(
+        "%s failed (consecutive failures: %d):",
+        func.name,
+        consecutiveFailures,
+        e,
+      );
+      // 2 ** capped so the exponent doesn't overflow on long outages
+      const exp = Math.min(consecutiveFailures, 10);
+      const backoff = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * 2 ** exp);
+      const jitter = Math.random() * 250;
+      await new Promise((resolve) => setTimeout(resolve, backoff + jitter));
+      continue;
+    }
+    consecutiveFailures = 0;
     const end = Date.now();
     console.log("%s: %dms", func.name, end - start);
     await redis.setex(


### PR DESCRIPTION
Previously any error thrown inside a `runInLoop` callback would propagate
all the way out of the worker module, the dynamic import in index.ts
would reject, and the process would sleep 250ms and exit(1) for PM2 to
restart. During a real outage (e.g. Postgres at max_connections), every
runInLoop-based worker (inserter, scanner, scanner2, rater, monitor,
cleanup, ...) crashes and restarts ~4x per second, each restart
reopening its Knex pool against an already-saturated DB and losing
in-flight Promise.all work. The system has no way to slow down.

This change wraps func() in try/catch, logs the error (still loudly,
via console.error, with a consecutive-failure count), and sleeps with
exponential backoff (250ms base, doubling, capped at 30s) plus jitter
before retrying. On success, the failure counter resets.

After `MAX_CONSECUTIVE_FAILURES` (10) in a row, the worker exits so PM2
can do a clean-slate restart (fresh Knex pool, cleared in-memory state)
rather than retrying at the 30s backoff cap forever. With the backoff
curve this is ~2 minutes of sustained failure before giving up — past
any transient DB blip, but short enough that a genuinely-wedged worker
still surfaces via crash + restart instead of silently retrying. Mirrors
the inserter watchdog's existing `process.exit(1)` pattern.

The existing lastRun:<APP_NAME> health beacon is only refreshed on
success, so a worker stuck in the failure path will still trip
HEALTH_TIMEOUT-based alerting. Workers that fail for non-transient
reasons (bad code, missing env) therefore still surface; they just
don't take the DB down with them on the way out.