### PR TITLE
Support Zstandard-compressed meta files by detecting magic bytes

### DIFF
--- a/svc/fetcher/MetaFetcher.ts
+++ b/svc/fetcher/MetaFetcher.ts
@@ -1,5 +1,6 @@
 import ProtoBuf from "protobufjs";
 import { spawn } from "node:child_process";
+import { zstdDecompressSync } from "node:zlib";
 import { buildReplayUrl } from "../util/utility.ts";
 import { MatchFetcherBase } from "./MatchFetcherBase.ts";
 import { GcdataFetcher } from "./GcdataFetcher.ts";
@@ -41,10 +42,18 @@ export class MetaFetcher extends MatchFetcherBase<Record<string, any>> {
     const start = Date.now();
     const resp = await fetch(url);
     const bzIn = Buffer.from(await resp.arrayBuffer());
-    const bz = spawn(`bunzip2`);
-    bz.stdin.write(bzIn);
-    bz.stdin.end();
-    const outBuf = await buffer(bz.stdout);
+    // Detect compression by magic bytes rather than URL extension: Valve switched
+    // meta files from bzip2 to Zstandard around 2026-07-27, keeping the .bz2 extension
+    const isZstd = bzIn.length >= 4 && bzIn.readUInt32LE(0) === 0xfd2fb528;
+    let outBuf: Buffer;
+    if (isZstd) {
+      outBuf = zstdDecompressSync(bzIn);
+    } else {
+      const bz = spawn(`bunzip2`);
+      bz.stdin.write(bzIn);
+      bz.stdin.end();
+      outBuf = await buffer(bz.stdout);
+    }
     const message: any = CDOTAMatchMetadataFile.decode(outBuf);
     // message.metadata.teams.forEach((team) => {
     //   team.players.forEach((player) => {


### PR DESCRIPTION
## Problem

Companion to odota/parser#86 — around ~18:00 UTC on July 27 Valve switched replay **and meta file** compression from bzip2 to Zstandard, keeping the `.bz2` extension:

```
$ curl -s -r 0-3 http://replay182.valve.net/570/8918058393_825192009.meta.bz2 | xxd
28b5 2ffd    Zstandard magic number (was "BZh9" before July 27)
```

`MetaFetcher.ts` pipes the download through `bunzip2` unconditionally, which now fails for every new match.

## Fix

Detect the format from the magic bytes: Zstandard (`0x28B52FFD`) is decompressed with `zstdDecompressSync` from `node:zlib` (native since Node 22.15, and core runs Node 24) — no new dependency, no external binary. Anything else keeps the existing `bunzip2` spawn path, so old meta files and any future format keep the current behavior.

Verified that the new zstd meta file above zstd-decompresses correctly (63 KB → 102 KB) and that the output is valid protobuf whose root fields match the `CDOTAMatchMetadataFile` schema (version, match_id, metadata, private_metadata).
