### PR TITLE
Document per-minute hero damage, healing and camp stack series

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -139,6 +139,9 @@ interface ParsedPlayer extends Player {
   gold_t: number[];
   xp_t: number[];
   lh_t: number[];
+  camps_stacked_t: number[];
+  hero_damage_t: number[];
+  hero_healing_t: number[];
   item_uses: NumberDict;
   buyback_log: any[];
   killed: NumberDict;

--- a/svc/api/responses/MatchResponse.ts
+++ b/svc/api/responses/MatchResponse.ts
@@ -313,6 +313,14 @@ export default {
               description: "Number of camps stacked",
               type: "integer",
             },
+            camps_stacked_t: {
+              description:
+                "Array containing number of camps stacked at different times of the match",
+              type: "array",
+              items: {
+                type: "integer",
+              },
+            },
             connection_log: {
               description:
                 "Array containing information about the player's disconnections and reconnections",
@@ -401,9 +409,25 @@ export default {
               description: "Hero Damage Dealt",
               type: "integer",
             },
+            hero_damage_t: {
+              description:
+                "Array containing cumulative damage dealt to enemy heroes at each minute of the match, as computed from the replay combat log. Follows the hero_damage scoreboard definition (real non-illusion hero targets, self-damage excluded, illusion attacker damage counted), so the final value matches hero_damage up to the last minute boundary",
+              type: "array",
+              items: {
+                type: "integer",
+              },
+            },
             hero_healing: {
               description: "Hero Healing Done",
               type: "integer",
+            },
+            hero_healing_t: {
+              description:
+                "Array containing cumulative healing done to other heroes at each minute of the match, as computed from the replay combat log. Follows the hero_healing scoreboard definition (self-healing excluded), so the final value matches hero_healing up to the last minute boundary",
+              type: "array",
+              items: {
+                type: "integer",
+              },
             },
             hero_hits: {
               description:


### PR DESCRIPTION
Companion to odota/parser#87. Adds `camps_stacked_t`, `hero_damage_t` and `hero_healing_t` to the `ParsedPlayer` type and the match response OpenAPI schema.

No inserts/migrations needed: `upsert` already filters against live `columnInfo()` so the new fields are dropped for Postgres, `player_caches` filters by its own column list, and the blob archive stores the full JSON — `buildMatch` spreads player objects so the fields flow to `GET /matches/{match_id}` automatically for newly parsed matches.
