### PR TITLE
Add deaths, assists and denies per minute benchmarks

### DIFF
--- a/svc/api/responses/BenchmarksResponse.ts
+++ b/svc/api/responses/BenchmarksResponse.ts
@@ -58,7 +58,55 @@ export default {
               },
             },
           },
+          deaths_per_min: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                percentile: {
+                  description: "percentile",
+                  type: "number",
+                },
+                value: {
+                  description: "value",
+                  type: "number",
+                },
+              },
+            },
+          },
+          assists_per_min: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                percentile: {
+                  description: "percentile",
+                  type: "number",
+                },
+                value: {
+                  description: "value",
+                  type: "number",
+                },
+              },
+            },
+          },
           last_hits_per_min: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                percentile: {
+                  description: "percentile",
+                  type: "number",
+                },
+                value: {
+                  description: "value",
+                  type: "number",
+                },
+              },
+            },
+          },
+          denies_per_min: {
             type: "array",
             items: {
               type: "object",

--- a/svc/util/benchmarksUtil.ts
+++ b/svc/util/benchmarksUtil.ts
@@ -11,8 +11,17 @@ export const benchmarks: Record<
   kills_per_min(m, p) {
     return (p.kills / m.duration) * 60;
   },
+  deaths_per_min(m, p) {
+    return (p.deaths / m.duration) * 60;
+  },
+  assists_per_min(m, p) {
+    return (p.assists / m.duration) * 60;
+  },
   last_hits_per_min(m, p) {
     return (p.last_hits / m.duration) * 60;
+  },
+  denies_per_min(m, p) {
+    return (p.denies / m.duration) * 60;
   },
   hero_damage_per_min(m, p) {
     return (p.hero_damage / m.duration) * 60;


### PR DESCRIPTION
First step of #2969: adds `deaths_per_min`, `assists_per_min` and `denies_per_min` to the benchmarks, following the same normalization as the existing `kills_per_min` / `last_hits_per_min`. All three come from Steam API match data, so no replay parsing is required and the sample size is the same as the current metrics.

No new key dimensions — this only adds metrics to the existing global zsets. Since `counts`, `getPlayerBenchmarks` and `getHeroBenchmarks` all iterate the shared metric map, the only code change is the map itself plus the OpenAPI schema.

One note: `deaths_per_min` percentiles read inverted (lower is better). I left the raw distribution for consistency with everything else, but happy to change that if you'd rather handle it differently.
