### PR TITLE
Add rank bracket segmentation to benchmarks

### DIFF
--- a/svc/api/spec.ts
+++ b/svc/api/spec.ts
@@ -1420,6 +1420,16 @@ You can use the API without a key, but registering for a key allows increased ra
               type: "string", // todo: String for hero id?
             },
           },
+          {
+            name: "bracket",
+            in: "query",
+            description:
+              "Rank bracket from 1 (Herald) to 8 (Immortal) to benchmark against. Omit for matches of all ranks",
+            required: false,
+            schema: {
+              type: "integer",
+            },
+          },
         ],
         responses: {
           200: {
@@ -1438,7 +1448,16 @@ You can use the API without a key, but registering for a key allows increased ra
           if (typeof req.query.hero_id !== "string") {
             return res.status(400).json({ error: "hero_id is not a string" });
           }
-          const result = await getHeroBenchmarks(req.query.hero_id);
+          let bracket: number | null = null;
+          if (req.query.bracket !== undefined) {
+            bracket = Number(req.query.bracket);
+            if (!Number.isInteger(bracket) || bracket < 1 || bracket > 8) {
+              return res
+                .status(400)
+                .json({ error: "bracket must be an integer between 1 and 8" });
+            }
+          }
+          const result = await getHeroBenchmarks(req.query.hero_id, bracket);
           return res.json(result);
         },
       },

--- a/svc/counts.ts
+++ b/svc/counts.ts
@@ -211,6 +211,8 @@ runReliableQueue("counts", 2, async (job: CountsJob, metadata) => {
 
     async function updateBenchmarks() {
       const turbo = isTurbo(match);
+      // 1 to 8 based on the average rank of the match, as in updateHeroCounts
+      const rank = !turbo && avg ? Math.floor(avg / 10) : null;
       if (
         match.match_id % 100 < Number(config.BENCHMARKS_SAMPLE_PERCENT) &&
         (isSignificant(match) || turbo)
@@ -242,6 +244,20 @@ runReliableQueue("counts", 2, async (job: CountsJob, metadata) => {
                   2,
                 );
                 redis.expireat(rkey, expiretime);
+                if (rank) {
+                  const rankKey = [
+                    "benchmarks",
+                    getStartOfBlockMinutes(
+                      Number(config.BENCHMARK_RETENTION_MINUTES),
+                      0,
+                    ),
+                    key,
+                    p.hero_id,
+                    rank,
+                  ].join(":");
+                  redis.zadd(rankKey, metric, match.match_id);
+                  redis.expireat(rankKey, expiretime);
+                }
               }
             });
           }

--- a/svc/counts.ts
+++ b/svc/counts.ts
@@ -245,16 +245,7 @@ runReliableQueue("counts", 2, async (job: CountsJob, metadata) => {
                 );
                 redis.expireat(rkey, expiretime);
                 if (rank) {
-                  const rankKey = [
-                    "benchmarks",
-                    getStartOfBlockMinutes(
-                      Number(config.BENCHMARK_RETENTION_MINUTES),
-                      0,
-                    ),
-                    key,
-                    p.hero_id,
-                    rank,
-                  ].join(":");
+                  const rankKey = `${rkey}:${rank}`;
                   redis.zadd(rankKey, metric, match.match_id);
                   redis.expireat(rankKey, expiretime);
                 }

--- a/svc/util/queries.ts
+++ b/svc/util/queries.ts
@@ -108,9 +108,11 @@ export async function getHeroItemPopularity(heroId: string) {
     late_game_items: lateGameItems,
   };
 }
-export async function getHeroBenchmarks(heroId: string) {
+export async function getHeroBenchmarks(heroId: string, bracket?: number | null) {
   const ret: AnyDict = {};
   const arr = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99];
+  // Keys end with an empty suffix for the global sets, or the 1-8 rank bracket
+  const suffix = bracket ? bracket.toString() : "";
   const items: [metric: string, percentile: number][] = [];
   Object.keys(benchmarks).forEach((metric) => {
     arr.forEach((percentile) => {
@@ -125,14 +127,14 @@ export async function getHeroBenchmarks(heroId: string) {
         getStartOfBlockMinutes(Number(config.BENCHMARK_RETENTION_MINUTES), -1),
         metric,
         heroId,
-        "",
+        suffix,
       ].join(":");
       const backupKey = [
         "benchmarks",
         getStartOfBlockMinutes(Number(config.BENCHMARK_RETENTION_MINUTES), 0),
         metric,
         heroId,
-        "",
+        suffix,
       ].join(":");
       const exists = await redis.exists(key);
       if (exists === 0) {

--- a/svc/util/queries.ts
+++ b/svc/util/queries.ts
@@ -111,8 +111,8 @@ export async function getHeroItemPopularity(heroId: string) {
 export async function getHeroBenchmarks(heroId: string, bracket?: number | null) {
   const ret: AnyDict = {};
   const arr = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99];
-  // Keys end with an empty suffix for the global sets, or the 1-8 rank bracket
-  const suffix = bracket ? bracket.toString() : "";
+  // Bracketed sets add the 1-8 rank bracket after the global/turbo slot
+  const suffix = bracket ? `:${bracket}` : "";
   const items: [metric: string, percentile: number][] = [];
   Object.keys(benchmarks).forEach((metric) => {
     arr.forEach((percentile) => {
@@ -122,20 +122,25 @@ export async function getHeroBenchmarks(heroId: string, bracket?: number | null)
   await Promise.all(
     items.map(async ([metric, percentile]) => {
       // Use data from previous epoch
-      let key = [
-        "benchmarks",
-        getStartOfBlockMinutes(Number(config.BENCHMARK_RETENTION_MINUTES), -1),
-        metric,
-        heroId,
-        suffix,
-      ].join(":");
-      const backupKey = [
-        "benchmarks",
-        getStartOfBlockMinutes(Number(config.BENCHMARK_RETENTION_MINUTES), 0),
-        metric,
-        heroId,
-        suffix,
-      ].join(":");
+      let key =
+        [
+          "benchmarks",
+          getStartOfBlockMinutes(
+            Number(config.BENCHMARK_RETENTION_MINUTES),
+            -1,
+          ),
+          metric,
+          heroId,
+          "",
+        ].join(":") + suffix;
+      const backupKey =
+        [
+          "benchmarks",
+          getStartOfBlockMinutes(Number(config.BENCHMARK_RETENTION_MINUTES), 0),
+          metric,
+          heroId,
+          "",
+        ].join(":") + suffix;
       const exists = await redis.exists(key);
       if (exists === 0) {
         // No data, use backup key (current epoch)


### PR DESCRIPTION
Second step of #2969, following what we discussed there: 8 individual brackets, bucketed by the match's `avg_rank_tier` the same way the hero pick/win counts do it. Matches without `avg_rank_tier` only feed the global sets, and the default `/benchmarks` response is unchanged.

Write side: `updateBenchmarks` zadds the same sampled value into `benchmarks:{epoch}:{metric}:{heroId}:{rank}` next to the existing global key, with the same expiry cycle. The bracket reuses the trailing key slot (`""` / `"turbo"` / `"1"`-`"8"`), so turbo stays global-only and there's no collision.

Read side: `GET /benchmarks?hero_id=X&bracket=5` reads percentiles from the bracketed sets (validated 1-8, 400 otherwise). Omitting the param behaves exactly as today.

One thing to be aware of: since benchmarks live only in Redis, the bracketed sets start filling on deploy — bracketed queries will be sparse until the current epoch completes. Nothing to migrate.
