### PR TITLE
Document deaths_log per-death gold lost and time dead

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -131,6 +131,7 @@ type Player = {
 
 interface ParsedPlayer extends Player {
   kills_log: any[];
+  deaths_log: any[];
   obs_log: any[];
   purchase_log: any[];
   pings: any;

--- a/svc/api/responses/MatchResponse.ts
+++ b/svc/api/responses/MatchResponse.ts
@@ -477,6 +477,34 @@ export default {
                 },
               },
             },
+            deaths_log: {
+              description:
+                "Array containing information on the player's deaths: when they died, to whom, the gold lost and the time spent dead. Only present for matches parsed after the field was added",
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  time: {
+                    description: "Time in seconds the player died",
+                    type: "integer",
+                  },
+                  key: {
+                    description: "Name of the killing unit",
+                    type: "string",
+                  },
+                  gold_lost: {
+                    description:
+                      "Gold lost to this death (0 on patches without death gold loss)",
+                    type: "integer",
+                  },
+                  time_dead: {
+                    description:
+                      "Seconds spent dead after this death. Absent if the match ended before the respawn",
+                    type: "integer",
+                  },
+                },
+              },
+            },
             lane_pos: {
               description: "Object containing information on lane position",
               type: "object",


### PR DESCRIPTION
﻿Companion to odota/parser#88, for #1465. Closes #2294, closes #1780 (both fully covered: the log records every real death with its killing unit, heroes or not, suicides included). Adds `deaths_log` to the `ParsedPlayer` type and the match response OpenAPI schema: per-death `{time, key, gold_lost, time_dead}` for parsed matches.

Same pattern as #2968: no inserts or migrations — the field lives in the parsed blob and flows to `GET /matches/{match_id}` for newly parsed matches; older parses just don't have it.

