### PR TITLE
Resolve the first blood victim to a player slot in the objectives

### DIFF
--- a/svc/util/buildMatch.ts
+++ b/svc/util/buildMatch.ts
@@ -1,6 +1,10 @@
 import { heroes } from "dotaconstants";
 import config from "../../config.ts";
-import { computeMatchData, estimatePositions } from "./compute.ts";
+import {
+  annotateFirstbloodVictim,
+  computeMatchData,
+  estimatePositions,
+} from "./compute.ts";
 import { buildReplayUrl, isTurbo } from "./utility.ts";
 import redis, { redisCount } from "../store/redis.ts";
 import db from "../store/db.ts";
@@ -267,6 +271,7 @@ export async function buildMatch(
   };
   computeMatchData(matchResult as ParsedPlayerMatch);
   estimatePositions(matchResult.players as ParsedPlayerMatch[]);
+  annotateFirstbloodVictim(matchResult);
 
   // Save in cache
   if (matchResult && config.ENABLE_MATCH_CACHE) {

--- a/svc/util/compute.ts
+++ b/svc/util/compute.ts
@@ -336,6 +336,27 @@ export function estimatePositions(players: ParsedPlayerMatch[]) {
 }
 
 /**
+ * The parser stores the first blood victim as the victim's 0-9 player index
+ * in the CHAT_MESSAGE_FIRSTBLOOD objective's key. Resolve it to a
+ * victim_player_slot field alongside the killer's player_slot
+ * (https://github.com/odota/core/issues/1488)
+ * */
+export function annotateFirstbloodVictim(match: {
+  objectives?: any[];
+  players?: Array<{ player_slot?: number }>;
+}) {
+  const firstblood = match.objectives?.find(
+    (o) => o.type === "CHAT_MESSAGE_FIRSTBLOOD",
+  );
+  const victim = firstblood
+    ? match.players?.[Number(firstblood.key)]
+    : undefined;
+  if (victim?.player_slot != null) {
+    firstblood.victim_player_slot = victim.player_slot;
+  }
+}
+
+/**
  * Determines if a match is significant for aggregation purposes
  * */
 export function isSignificant(match: Match | ApiData) {


### PR DESCRIPTION
Closes #1488.

The data has been there all along: since 2017 the parser's `handleFirstblood` stores the victim's 0-9 player index in the `CHAT_MESSAGE_FIRSTBLOOD` objective's `key` ([Parse.java emits `player2`, CreateParsedDataBlob keys it](https://github.com/odota/parser/blob/master/src/main/java/opendota/CreateParsedDataBlob.java)), but nothing downstream interprets it — consumers see `"key": "8"` with no way to tell it's the victim.

This annotates the objective at query time in `buildMatch` (same pattern as `position_est`): a `victim_player_slot` field resolved through the players array. Because it's query time, it works retroactively for every already-parsed match — no reparse needed.

Example output for match 8754463676:

```json
{"time": 58, "type": "CHAT_MESSAGE_FIRSTBLOOD", "key": "8", "slot": 0, "player_slot": 0, "victim_player_slot": 131}
```

Validated against two production matches:
- 8754463676 → `victim_player_slot: 131` (Keeper of the Light; the killer's `kills_log` has `npc_dota_hero_keeper_of_the_light` at the same second)
- 8813802531 → `victim_player_slot: 1` (Beastmaster; Lone Druid's `kills_log` shows the kill at 16s and Beastmaster's `killed_by` includes him)

Old parses without the field (`key: "null"`) and non-standard player arrays are guarded — the field is simply absent. Typecheck clean except the two pre-existing Stripe errors on master.
