### PR TITLE
Invert deaths_per_min benchmark percentile

### DIFF
--- a/svc/util/buildMatch.ts
+++ b/svc/util/buildMatch.ts
@@ -134,7 +134,10 @@ export async function getPlayerBenchmarks(m: Match) {
         const card = await redis.zcard(key);
         if (raw !== undefined && raw !== null && !Number.isNaN(Number(raw))) {
           const count = await redis.zcount(key, "0", raw);
-          const pct = count / card;
+          // deaths_per_min is the one metric where lower is better, so its
+          // percentile is the share of players with a higher value
+          const pct =
+            metric === "deaths_per_min" ? 1 - count / card : count / card;
           result[metric].pct = pct;
         }
       }


### PR DESCRIPTION
Follow-up to #2970: deaths_per_min is the one benchmark where a lower value is better, but its percentile is computed like the others (share of players at or below your value), so right now a 12-death game shows as ~67th percentile and gets colored as great on the match page, while a deathless one shows ~2% in red. This computes it as the share of players with a higher value instead.

You can see it on any current match, e.g. 8754463676: the deathless player is the red 0.91% in the DPM column.

![benchmarks tab](https://raw.githubusercontent.com/geracosta/web/assets/benchmark-labels-demo.jpg)