### PR TITLE
Add bracket percentile to player benchmarks

### DIFF
--- a/svc/util/buildMatch.ts
+++ b/svc/util/buildMatch.ts
@@ -8,6 +8,7 @@ import { benchmarks } from "./benchmarksUtil.ts";
 import * as allFetchers from "../fetcher/allFetchers.ts";
 import { getMatchBlob } from "./getMatchBlob.ts";
 import { getStartOfBlockMinutes } from "./time.ts";
+import { getMatchRankTier } from "./queries.ts";
 import { isContributor } from "../../CONTRIBUTORS.ts";
 
 const { metaFetcher } = allFetchers;
@@ -99,9 +100,16 @@ async function getProMatchInfo(match: Match): Promise<ProMatchInfo> {
  * */
 export async function getPlayerBenchmarks(m: Match) {
   const turbo = isTurbo(m);
+  // Bracket 1-8 from the average rank of the players, matching what the
+  // write side does in counts.ts (turbo only has global benchmarks)
+  const { avg } = turbo ? { avg: null } : await getMatchRankTier(db, m.players);
+  const bracket = avg ? Math.floor(avg / 10) : null;
   return Promise.all(
     m.players.map(async (p) => {
-      const result: Record<string, { raw?: number; pct?: number }> = {};
+      const result: Record<
+        string,
+        { raw?: number; pct?: number; pct_bracket?: number }
+      > = {};
       for (let metric of Object.keys(benchmarks)) {
         result[metric] = {};
         // Use data from previous epoch
@@ -139,6 +147,18 @@ export async function getPlayerBenchmarks(m: Match) {
           const pct =
             metric === "deaths_per_min" ? 1 - count / card : count / card;
           result[metric].pct = pct;
+          if (bracket) {
+            // Same distribution restricted to this match's rank bracket
+            const bracketKey = `${key}:${bracket}`;
+            const bracketCard = await redis.zcard(bracketKey);
+            if (bracketCard > 0) {
+              const bracketCount = await redis.zcount(bracketKey, "0", raw);
+              result[metric].pct_bracket =
+                metric === "deaths_per_min"
+                  ? 1 - bracketCount / bracketCard
+                  : bracketCount / bracketCard;
+            }
+          }
         }
       }
       return result;

--- a/svc/util/buildMatch.ts
+++ b/svc/util/buildMatch.ts
@@ -134,7 +134,10 @@ export async function getPlayerBenchmarks(m: Match) {
         const card = await redis.zcard(key);
         if (raw !== undefined && raw !== null && !Number.isNaN(Number(raw))) {
           const count = await redis.zcount(key, "0", raw);
-          const pct = count / card;
+          // deaths_per_min is the one metric where lower is better, so its
+          // percentile is the share of players with a higher value
+          const pct =
+            metric === "deaths_per_min" ? 1 - count / card : count / card;
           result[metric].pct = pct;
         }
       }


### PR DESCRIPTION
Adds a `pct_bracket` field next to `pct` in the match players' benchmarks: the same percentile computed against only the matches in this match's rank bracket, using the bracket zsets from #2972. The bracket is derived from the players' average rank with getMatchRankTier, same as the write side in counts.ts. Skipped for turbo (no bracket keys) and when the bracket zset is empty, so the field is additive and consumers that don't know about it see no change.

odota/web#3373 uses it to add a line to the benchmark tooltips: "Equal or higher than X% at this match's average rank".

Note: branched on top of #2978 since both touch the same lines of getPlayerBenchmarks (the deaths_per_min inversion applies to the bracket percentile too).